### PR TITLE
Update build name

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -3,6 +3,11 @@ name: Android Release Build
 # Workflow that builds release APK each time code changes.
 # This allows developers and testers to easily download the latest release APK.
 # This is also useful to download the APK and add to to the GitHub release.
+#
+# See:
+# - https://github.com/usetrmnl/trmnl-android/tree/main/keystore
+# - https://github.com/usetrmnl/trmnl-android/blob/main/app/build.gradle.kts#L44-L55
+
 
 on:
   push:
@@ -38,11 +43,11 @@ jobs:
       - name: Rename APK
         run: |
           mkdir -p artifact
-          cp app/build/outputs/apk/release/app-release.apk artifact/trmnl-display-v${{ steps.version.outputs.VERSION }}.apk
+          cp app/build/outputs/apk/release/app-release.apk artifact/trmnl-mirror-v${{ steps.version.outputs.VERSION }}.apk
 
       - name: Upload Release APK
         uses: actions/upload-artifact@v4
         with:
-          name: trmnl-display-app
-          path: artifact/trmnl-display-v${{ steps.version.outputs.VERSION }}.apk
+          name: trmnl-mirror-app
+          path: artifact/trmnl-mirror-v${{ steps.version.outputs.VERSION }}.apk
           retention-days: 7

--- a/.idea/icon.svg
+++ b/.idea/icon.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 90 90" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1.03581,0,0,1.03581,-2.32425,-2.14918)">
+        <path d="M89.132,16.101L89.132,74.937C89.132,82.678 82.847,88.963 75.106,88.963L16.27,88.963C8.529,88.963 2.244,82.678 2.244,74.937L2.244,16.101C2.244,8.36 8.529,2.075 16.27,2.075L75.106,2.075C82.847,2.075 89.132,8.36 89.132,16.101Z" style="fill:rgb(248,101,39);"/>
+    </g>
+    <path d="M24.07,6.34L47.66,15.22L43.28,26.95L19.69,18.07L24.07,6.34Z" style="fill:white;"/>
+    <path d="M61.89,3.44L69.68,27.5L57.81,31.37L50.02,7.31L61.89,3.44Z" style="fill:white;"/>
+    <path d="M87.73,31.34L73.85,52.46L63.43,45.56L77.31,24.44L87.73,31.34Z" style="fill:white;"/>
+    <path d="M82.12,69.01L57.02,71.28L55.9,58.8L81,56.53L82.12,69.01Z" style="fill:white;"/>
+    <path d="M49.29,88.09L31.87,69.81L40.89,61.15L58.31,79.43L49.29,88.09Z" style="fill:white;"/>
+    <path d="M13.96,74.23L17.34,49.16L29.71,50.84L26.33,75.91L13.96,74.23Z" style="fill:white;"/>
+    <path d="M2.73,37.82L24.36,24.84L30.76,35.59L9.13,48.57L2.73,37.82Z" style="fill:white;"/>
+</svg>

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ The app uses a modern Android architecture with the following components:
 ## Related References 📖
 * https://usetrmnl.com/
 * https://usetrmnl.com/integrations
-* https://github.com/usetrmnl/trmnl-display
+* https://github.com/usetrmnl/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 activityCompose = "1.10.1"
 # https://developer.android.com/jetpack/androidx/releases/compose-material3-adaptive
-adaptive = "1.2.0-alpha03"
+adaptive = "1.2.0-alpha04"
 agp = "8.9.1"
 anvil = "0.4.1"
 circuit = "0.27.1"


### PR DESCRIPTION
This pull request includes updates to the Android release workflow, documentation, and dependency versions. The most important changes include renaming the APK and artifact references, updating links in the documentation, and upgrading a dependency version.

### Workflow updates:
* [`.github/workflows/android-release.yml`](diffhunk://#diff-2bd036fee148e164b04b1752776190a94d546194cfea150a5936f4ed3930f1d8L41-R52): Renamed the APK file and artifact references from `trmnl-display` to `trmnl-mirror` to reflect a naming change.
* [`.github/workflows/android-release.yml`](diffhunk://#diff-2bd036fee148e164b04b1752776190a94d546194cfea150a5936f4ed3930f1d8R6-R10): Added comments with links to the keystore and build configuration files for better context.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L115-R115): Updated the related references section to replace the `trmnl-display` GitHub repository link with the organization-level link.

### Dependency updates:
* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL4-R4): Upgraded the `adaptive` dependency from version `1.2.0-alpha03` to `1.2.0-alpha04`.