### PR TITLE
[FIXED] Image caching issue - disabled plugin image cache

### DIFF
--- a/app/src/main/java/ink/trmnl/android/util/CoilRequestUtils.kt
+++ b/app/src/main/java/ink/trmnl/android/util/CoilRequestUtils.kt
@@ -45,8 +45,11 @@ object CoilRequestUtils {
                 if (enableCrossfade) {
                     crossfade(true)
                 }
-            }.memoryCachePolicy(CachePolicy.ENABLED)
-            .diskCachePolicy(CachePolicy.ENABLED)
-            .networkCachePolicy(CachePolicy.ENABLED)
+            }
+            // ℹ️ URL based caching is disabled because URL stays the same based on current design
+            // See https://discord.com/channels/1281055965508141100/1284986536357662740/1369152339084316754
+            .memoryCachePolicy(CachePolicy.DISABLED)
+            .diskCachePolicy(CachePolicy.DISABLED)
+            .networkCachePolicy(CachePolicy.DISABLED)
             .build()
 }


### PR DESCRIPTION
Fixes #34

This pull request modifies the caching behavior in the `CoilRequestUtils` utility to disable URL-based caching. This change addresses an issue where the URL remains constant in the current design, making caching ineffective.

### Changes to caching behavior:
* [`app/src/main/java/ink/trmnl/android/util/CoilRequestUtils.kt`](diffhunk://#diff-6e96e4f49fb3190439171f2ae844218ee5e6390c2bc3944053abbbec2f394fdeL48-R53): Updated the `memoryCachePolicy`, `diskCachePolicy`, and `networkCachePolicy` to `CachePolicy.DISABLED` with a comment explaining that URL-based caching is disabled due to the URL staying the same in the current design.