### PR TITLE
Fix/25 44 better error message

### DIFF
--- a/app/src/main/java/ink/trmnl/android/data/TrmnlDisplayInfo.kt
+++ b/app/src/main/java/ink/trmnl/android/data/TrmnlDisplayInfo.kt
@@ -3,6 +3,9 @@ package ink.trmnl.android.data
 import androidx.annotation.Keep
 import ink.trmnl.android.data.AppConfig.DEFAULT_REFRESH_INTERVAL_SEC
 import ink.trmnl.android.model.TrmnlDeviceType
+import ink.trmnl.android.util.HTTP_200
+import ink.trmnl.android.util.HTTP_500
+import ink.trmnl.android.util.HTTP_OK
 
 /**
  * Represents the display information for the TRMNL.
@@ -10,6 +13,9 @@ import ink.trmnl.android.model.TrmnlDeviceType
  */
 @Keep
 data class TrmnlDisplayInfo constructor(
+    /**
+     * See [HTTP_OK], [HTTP_200], [HTTP_500].
+     */
     val status: Int,
     val trmnlDeviceType: TrmnlDeviceType,
     val imageUrl: String,

--- a/app/src/main/java/ink/trmnl/android/data/TrmnlDisplayRepository.kt
+++ b/app/src/main/java/ink/trmnl/android/data/TrmnlDisplayRepository.kt
@@ -7,8 +7,8 @@ import ink.trmnl.android.di.AppScope
 import ink.trmnl.android.model.TrmnlDeviceConfig
 import ink.trmnl.android.model.TrmnlDeviceType
 import ink.trmnl.android.network.TrmnlApiService
-import ink.trmnl.android.network.TrmnlApiService.Companion.CURRENT_SCREEN_ENDPOINT
-import ink.trmnl.android.network.TrmnlApiService.Companion.NEXT_DISPLAY_ENDPOINT
+import ink.trmnl.android.network.TrmnlApiService.Companion.CURRENT_PLAYLIST_SCREEN_API_PATH
+import ink.trmnl.android.network.TrmnlApiService.Companion.NEXT_PLAYLIST_SCREEN_API_PATH
 import ink.trmnl.android.util.HTTP_200
 import ink.trmnl.android.util.HTTP_500
 import ink.trmnl.android.util.isHttpOk
@@ -50,7 +50,7 @@ class TrmnlDisplayRepository
             val response =
                 apiService
                     .getNextDisplayData(
-                        fullApiUrl = constructApiUrl(trmnlDeviceConfig.apiBaseUrl, NEXT_DISPLAY_ENDPOINT),
+                        fullApiUrl = constructApiUrl(trmnlDeviceConfig.apiBaseUrl, NEXT_PLAYLIST_SCREEN_API_PATH),
                         accessToken = trmnlDeviceConfig.apiAccessToken,
                     ).successOrNull()
 
@@ -94,7 +94,7 @@ class TrmnlDisplayRepository
             val response =
                 apiService
                     .getCurrentDisplayData(
-                        fullApiUrl = constructApiUrl(trmnlDeviceConfig.apiBaseUrl, CURRENT_SCREEN_ENDPOINT),
+                        fullApiUrl = constructApiUrl(trmnlDeviceConfig.apiBaseUrl, CURRENT_PLAYLIST_SCREEN_API_PATH),
                         accessToken = trmnlDeviceConfig.apiAccessToken,
                     ).successOrNull()
 

--- a/app/src/main/java/ink/trmnl/android/data/TrmnlDisplayRepository.kt
+++ b/app/src/main/java/ink/trmnl/android/data/TrmnlDisplayRepository.kt
@@ -174,13 +174,20 @@ class TrmnlDisplayRepository
             }
 
         /**
-         * Converts API failure results into a [TrmnlDisplayInfo] object with proper error info.
+         * Converts an API failure result into a [TrmnlDisplayInfo] object with appropriate error details.
+         *
+         * This function handles different types of API failures and maps them to a standardized
+         * [TrmnlDisplayInfo] object. The returned object contains error information and default values
+         * for other fields.
          */
         private fun failedTrmnlDisplayInfo(
             trmnlDeviceConfig: TrmnlDeviceConfig,
             failure: ApiResult.Failure<Unit>,
         ): TrmnlDisplayInfo =
             when (failure) {
+                /**
+                 * Handles API-specific failures, returning a [TrmnlDisplayInfo] with a generic API failure message.
+                 */
                 is ApiResult.Failure.ApiFailure -> {
                     TrmnlDisplayInfo(
                         status = HTTP_500,
@@ -192,6 +199,9 @@ class TrmnlDisplayRepository
                     )
                 }
 
+                /**
+                 * Handles HTTP failures, including the HTTP status code and error message in the result.
+                 */
                 is ApiResult.Failure.HttpFailure -> {
                     TrmnlDisplayInfo(
                         status = HTTP_500,
@@ -203,6 +213,9 @@ class TrmnlDisplayRepository
                     )
                 }
 
+                /**
+                 * Handles network-related failures, including the localized error message in the result.
+                 */
                 is ApiResult.Failure.NetworkFailure -> {
                     TrmnlDisplayInfo(
                         status = HTTP_500,
@@ -214,6 +227,9 @@ class TrmnlDisplayRepository
                     )
                 }
 
+                /**
+                 * Handles unknown failures, including the localized error message in the result.
+                 */
                 is ApiResult.Failure.UnknownFailure -> {
                     TrmnlDisplayInfo(
                         status = HTTP_500,

--- a/app/src/main/java/ink/trmnl/android/network/TrmnlApiService.kt
+++ b/app/src/main/java/ink/trmnl/android/network/TrmnlApiService.kt
@@ -15,24 +15,29 @@ import retrofit2.http.Url
  *
  * See:
  * - https://docs.usetrmnl.com/go
+ * - https://docs.usetrmnl.com/go/private-api/introduction
  *
  * @see TrmnlDisplayRepository
  */
 interface TrmnlApiService {
     companion object {
         /**
+         * https://docs.usetrmnl.com/go/private-api/fetch-screen-content#auto-advance-content
+         *
          * @see getNextDisplayData
          */
-        internal const val NEXT_DISPLAY_ENDPOINT = "api/display"
+        internal const val NEXT_PLAYLIST_SCREEN_API_PATH = "api/display"
 
         /**
+         * https://docs.usetrmnl.com/go/private-api/fetch-screen-content#current-screen
+         *
          * @see getCurrentDisplayData
          */
-        internal const val CURRENT_SCREEN_ENDPOINT = "api/current_screen"
+        internal const val CURRENT_PLAYLIST_SCREEN_API_PATH = "api/current_screen"
     }
 
     /**
-     * Retrieve TRMNL image data, device-free using [NEXT_DISPLAY_ENDPOINT].
+     * Retrieve TRMNL image data, device-free using [NEXT_PLAYLIST_SCREEN_API_PATH].
      *
      * NOTE: This API always loads the next plugin image from the playlist.
      *
@@ -45,7 +50,7 @@ interface TrmnlApiService {
     ): ApiResult<TrmnlDisplayResponse, Unit>
 
     /**
-     * Retrieve TRMNL image that is currently being displayed using [CURRENT_SCREEN_ENDPOINT].
+     * Retrieve TRMNL image that is currently being displayed using [CURRENT_PLAYLIST_SCREEN_API_PATH].
      *
      * NOTE: This API always loads the current plugin image from the playlist.
      *


### PR DESCRIPTION
Fixes #25 

Fixes #44 

This pull request refactors the `TrmnlDisplayRepository` and related classes to improve error handling, align API endpoint naming conventions, and enhance maintainability. The key changes include replacing `successOrNull` with `ApiResult` for better error management, updating API endpoint constants for clarity, and adding a helper method to standardize failure handling.

### Improved error handling:
* Replaced `successOrNull` with `ApiResult` in `TrmnlDisplayRepository` to handle API responses more robustly, including distinct handling for success and failure cases. (`app/src/main/java/ink/trmnl/android/data/TrmnlDisplayRepository.kt`, [[1]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62L50-R75) [[2]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62L94-R127)
* Added a new private method, `failedTrmnlDisplayInfo`, to map different types of API failures (e.g., HTTP, network, unknown) to standardized `TrmnlDisplayInfo` objects. (`app/src/main/java/ink/trmnl/android/data/TrmnlDisplayRepository.kt`, [app/src/main/java/ink/trmnl/android/data/TrmnlDisplayRepository.ktR175-R243](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62R175-R243))

### API endpoint naming updates:
* Renamed `NEXT_DISPLAY_ENDPOINT` to `NEXT_PLAYLIST_SCREEN_API_PATH` and `CURRENT_SCREEN_ENDPOINT` to `CURRENT_PLAYLIST_SCREEN_API_PATH` for better alignment with their functionality and documentation. (`app/src/main/java/ink/trmnl/android/network/TrmnlApiService.kt`, [[1]](diffhunk://#diff-ea87cc9cefcbbe3aeb57f63af2720d87719be2e40e863d18b0877cbd60efb73bR18-R40) [[2]](diffhunk://#diff-ea87cc9cefcbbe3aeb57f63af2720d87719be2e40e863d18b0877cbd60efb73bL48-R53)

### Miscellaneous improvements:
* Updated imports and added references to constants like `HTTP_200` and `HTTP_500` in `TrmnlDisplayInfo` for better readability and maintainability. (`app/src/main/java/ink/trmnl/android/data/TrmnlDisplayInfo.kt`, [app/src/main/java/ink/trmnl/android/data/TrmnlDisplayInfo.ktR6-R18](diffhunk://#diff-05c39440088d6d4c47ffdf57478c980f7648d47f2a2cd615511baccc73f84127R6-R18))
* Enhanced documentation with links to relevant API documentation for better developer context. (`app/src/main/java/ink/trmnl/android/network/TrmnlApiService.kt`, [app/src/main/java/ink/trmnl/android/network/TrmnlApiService.ktR18-R40](diffhunk://#diff-ea87cc9cefcbbe3aeb57f63af2720d87719be2e40e863d18b0877cbd60efb73bR18-R40))