### PR TITLE
[UPDATE] Downgrades target SDK to Android 9 (API 28)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         applicationId = "ink.trmnl.android"
-        minSdk = 30
+        minSdk = 28
         targetSdk = 35
         versionCode = 5
         versionName = "1.4.0"

--- a/app/src/main/java/ink/trmnl/android/di/NetworkModule.kt
+++ b/app/src/main/java/ink/trmnl/android/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package ink.trmnl.android.di
 
 import android.content.Context
+import androidx.core.content.pm.PackageInfoCompat
 import com.slack.eithernet.integration.retrofit.ApiResultCallAdapterFactory
 import com.slack.eithernet.integration.retrofit.ApiResultConverterFactory
 import com.squareup.anvil.annotations.ContributesTo
@@ -42,7 +43,7 @@ object NetworkModule {
         val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
         val appName = context.getString(context.applicationInfo.labelRes)
         val versionName = packageInfo.versionName
-        val versionCode = packageInfo.longVersionCode
+        val versionCode = PackageInfoCompat.getLongVersionCode(packageInfo)
 
         val userAgent = "$appName/$versionName (build:$versionCode; Android ${android.os.Build.VERSION.RELEASE})"
 

--- a/app/src/main/java/ink/trmnl/android/di/NetworkModule.kt
+++ b/app/src/main/java/ink/trmnl/android/di/NetworkModule.kt
@@ -43,6 +43,8 @@ object NetworkModule {
         val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
         val appName = context.getString(context.applicationInfo.labelRes)
         val versionName = packageInfo.versionName
+        // Use PackageInfoCompat.getLongVersionCode to ensure compatibility with API 28+ 
+        // while avoiding direct calls to longVersionCode on older devices.
         val versionCode = PackageInfoCompat.getLongVersionCode(packageInfo)
 
         val userAgent = "$appName/$versionName (build:$versionCode; Android ${android.os.Build.VERSION.RELEASE})"

--- a/app/src/main/java/ink/trmnl/android/di/NetworkModule.kt
+++ b/app/src/main/java/ink/trmnl/android/di/NetworkModule.kt
@@ -43,7 +43,7 @@ object NetworkModule {
         val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
         val appName = context.getString(context.applicationInfo.labelRes)
         val versionName = packageInfo.versionName
-        // Use PackageInfoCompat.getLongVersionCode to ensure compatibility with API 28+ 
+        // Use PackageInfoCompat.getLongVersionCode to ensure compatibility with API 28+
         // while avoiding direct calls to longVersionCode on older devices.
         val versionCode = PackageInfoCompat.getLongVersionCode(packageInfo)
 


### PR DESCRIPTION
Reason for not going 26 is:

```
Lint found 2 errors, 115 warnings. First failure:

/Users/hossain/dev/repos/os-android-apps/trmnl-android/app/src/main/java/ink/trmnl/android/di/TrmnlAppComponentFactory.kt:29: Error: Call requires API level 28 (current min is 26): AppComponentFactory [NewApi]

Version of android.app.AppComponentFactory that works with androidx libraries. Note: This will only work on API 28+ and does not backport AppComponentFactory functionality.
```

Applied changes to fix following:

```
  Lint found 3 errors, 115 warnings. First failure:

  /Users/hossain/dev/repos/os-android-apps/trmnl-android/app/src/main/java/ink/trmnl/android/di/NetworkModule.kt:45: Error: Call requires API level 28 (current min is 26): android.content.pm.PackageInfo#getLongVersionCode [NewApi]
          val versionCode = packageInfo.longVersionCode
                                        ~~~~~~~~~~~~~~~
```

Fixes https://github.com/usetrmnl/trmnl-android/issues/55