### PR TITLE
[ADDED] Image loading error handling with messaging

### DIFF
--- a/app/src/main/java/ink/trmnl/android/ui/display/TrmnlMirrorDisplayScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/ui/display/TrmnlMirrorDisplayScreen.kt
@@ -91,6 +91,10 @@ data object TrmnlMirrorDisplayScreen : Screen {
         data object BackPressed : Event()
 
         data object ToggleOverlayControls : Event()
+
+        data class ImageLoadingError(
+            val message: String,
+        ) : Event()
     }
 }
 
@@ -230,6 +234,11 @@ class TrmnlMirrorDisplayPresenter
                                 Timber.w("Refresh failed: No access token found")
                             }
                         }
+
+                        is TrmnlMirrorDisplayScreen.Event.ImageLoadingError -> {
+                            error = event.message
+                            isLoading = false
+                        }
                     }
                 },
             )
@@ -311,6 +320,15 @@ fun TrmnlMirrorDisplayContent(
                         contentDescription = "Terminal Display",
                         contentScale = ContentScale.Fit,
                         placeholder = painterResource(R.drawable.trmnl_logo_semi_transparent),
+                        error = painterResource(R.drawable.trmnl_logo_semi_transparent),
+                        onError = { error ->
+                            Timber.e("Image loading failed: ${error.result.throwable}")
+                            state.eventSink(
+                                TrmnlMirrorDisplayScreen.Event.ImageLoadingError(
+                                    "Failed to load image: ${error.result.throwable.message ?: "Unknown error"}",
+                                ),
+                            )
+                        },
                         modifier = Modifier.fillMaxSize(),
                     )
                 }

--- a/app/src/main/res/drawable/content_copy_24dp.xml
+++ b/app/src/main/res/drawable/content_copy_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M360,720q-33,0 -56.5,-23.5T280,640v-480q0,-33 23.5,-56.5T360,80h360q33,0 56.5,23.5T800,160v480q0,33 -23.5,56.5T720,720L360,720ZM360,640h360v-480L360,160v480ZM200,880q-33,0 -56.5,-23.5T120,800v-560h80v560h440v80L200,880ZM360,640v-480,480Z"
+      android:fillColor="#e8eaed"/>
+</vector>


### PR DESCRIPTION
Fixes #63

https://github.com/user-attachments/assets/56b16a3f-1d70-4580-9336-f4f42ac2e64e


---

This pull request introduces two main enhancements: improved error handling for image loading in the `TrmnlMirrorDisplayScreen` and a new feature to copy image URLs to the clipboard in the `DisplayRefreshLogScreen`. Below are the most important changes grouped by theme:

### Error Handling in `TrmnlMirrorDisplayScreen`
* Added a new `ImageLoadingError` event to handle image loading failures, including a message property to store error details (`TrmnlMirrorDisplayScreen.kt`, [app/src/main/java/ink/trmnl/android/ui/display/TrmnlMirrorDisplayScreen.ktR94-R97](diffhunk://#diff-a5a961f6b906903460af3b82ab8df178d8a853acbb73b93a80dcffa2fc108a12R94-R97)).
* Updated the `TrmnlMirrorDisplayPresenter` to handle the `ImageLoadingError` event by stopping the loading state and setting the error message (`TrmnlMirrorDisplayScreen.kt`, [app/src/main/java/ink/trmnl/android/ui/display/TrmnlMirrorDisplayScreen.ktR237-R241](diffhunk://#diff-a5a961f6b906903460af3b82ab8df178d8a853acbb73b93a80dcffa2fc108a12R237-R241)).
* Enhanced the `TrmnlMirrorDisplayContent` composable to log image loading errors and trigger the `ImageLoadingError` event when an error occurs (`TrmnlMirrorDisplayScreen.kt`, [app/src/main/java/ink/trmnl/android/ui/display/TrmnlMirrorDisplayScreen.ktR323-R331](diffhunk://#diff-a5a961f6b906903460af3b82ab8df178d8a853acbb73b93a80dcffa2fc108a12R323-R331)).

### URL Copy Feature in `DisplayRefreshLogScreen`
* Introduced a `SnackbarHostState` to display feedback messages and passed it to the `LogItemView` composable (`DisplayRefreshLogScreen.kt`, [[1]](diffhunk://#diff-94bfd6cf8beca7394310747d0c48467ad7fa397f7417d2311b701f5064f30675R226-R230) [[2]](diffhunk://#diff-94bfd6cf8beca7394310747d0c48467ad7fa397f7417d2311b701f5064f30675L298-R309).
* Added clipboard functionality to copy image URLs, along with a snackbar notification to confirm the action (`DisplayRefreshLogScreen.kt`, [[1]](diffhunk://#diff-94bfd6cf8beca7394310747d0c48467ad7fa397f7417d2311b701f5064f30675R325-R329) [[2]](diffhunk://#diff-94bfd6cf8beca7394310747d0c48467ad7fa397f7417d2311b701f5064f30675R418-R439).
* Updated preview functions to include the `SnackbarHostState` for testing the new feature (`DisplayRefreshLogScreen.kt`, [[1]](diffhunk://#diff-94bfd6cf8beca7394310747d0c48467ad7fa397f7417d2311b701f5064f30675L638-R675) [[2]](diffhunk://#diff-94bfd6cf8beca7394310747d0c48467ad7fa397f7417d2311b701f5064f30675L657-R694).

### Asset Addition
* Added a new vector drawable `content_copy_24dp.xml` for the "Copy URL" icon (`content_copy_24dp.xml`, [app/src/main/res/drawable/content_copy_24dp.xmlR1-R9](diffhunk://#diff-26c4ddf39df61b11a55643e5b9554d24e88f4694b24bdd11749c36f14e4465a9R1-R9)).