### PR TITLE
[REFACTOR] HTTP metadata view to have preview

### DIFF
--- a/app/src/main/java/ink/trmnl/android/ui/refreshlog/HttpResponseDetailsBottomSheet.kt
+++ b/app/src/main/java/ink/trmnl/android/ui/refreshlog/HttpResponseDetailsBottomSheet.kt
@@ -19,8 +19,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ink.trmnl.android.data.HttpResponseMetadata
+import ink.trmnl.android.ui.theme.TrmnlDisplayAppTheme
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -46,79 +48,85 @@ fun HttpResponseDetailsBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
     ) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 24.dp, vertical = 16.dp),
-        ) {
-            Text(
-                text = "HTTP Response Details",
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-            )
+        HttpResponseMetadataDisplay(httpResponseMetadata)
+    }
+}
 
-            Spacer(modifier = Modifier.height(16.dp))
+@Composable
+private fun HttpResponseMetadataDisplay(httpResponseMetadata: HttpResponseMetadata) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+    ) {
+        Text(
+            text = "HTTP Response Details",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
 
-            // Request URL
-            DetailItem(label = "Request URL", value = httpResponseMetadata.url)
+        Spacer(modifier = Modifier.height(16.dp))
 
-            // HTTP Status
-            DetailItem(
-                label = "HTTP Status",
-                value = "${httpResponseMetadata.statusCode} ${httpResponseMetadata.message}",
-            )
+        // Request URL
+        DetailItem(label = "Request URL", value = httpResponseMetadata.url)
 
-            // Protocol
-            DetailItem(
-                label = "HTTP Protocol",
-                value = if (httpResponseMetadata.protocol == "h2") "HTTP/2" else httpResponseMetadata.protocol,
-            )
+        // HTTP Status
+        DetailItem(
+            label = "HTTP Status",
+            value = "${httpResponseMetadata.statusCode} ${httpResponseMetadata.message}",
+        )
 
-            // Server
-            httpResponseMetadata.serverName?.let {
-                DetailItem(label = "Server", value = it)
-            }
+        // Protocol
+        DetailItem(
+            label = "HTTP Protocol",
+            value = if (httpResponseMetadata.protocol == "h2") "HTTP/2" else httpResponseMetadata.protocol,
+        )
 
-            // Content Type
-            httpResponseMetadata.contentType?.let {
-                DetailItem(label = "Content Type", value = it)
-            }
-
-            // Content Length
-            if (httpResponseMetadata.contentLength >= 0) {
-                DetailItem(
-                    label = "Content Length",
-                    value = formatBytes(httpResponseMetadata.contentLength),
-                )
-            }
-
-            // ETag (for cache validation)
-            httpResponseMetadata.etag?.let {
-                DetailItem(label = "ETag", value = it)
-            }
-
-            // Request ID (for server-side tracing)
-            httpResponseMetadata.requestId?.let {
-                DetailItem(label = "Request ID", value = it)
-            }
-
-            // Request Duration
-            if (httpResponseMetadata.requestDuration > 0) {
-                DetailItem(
-                    label = "Request Duration",
-                    value = "${httpResponseMetadata.requestDuration}ms",
-                )
-            }
-
-            // Timestamp
-            val dateFormat = remember { SimpleDateFormat("MMM dd, yyyy hh:mm:ss.SSS a", Locale.getDefault()) }
-            val formattedTimestamp = dateFormat.format(Date(httpResponseMetadata.timestamp))
-            DetailItem(label = "Response Time", value = formattedTimestamp)
-
-            Spacer(modifier = Modifier.height(24.dp))
+        // Server
+        httpResponseMetadata.serverName?.let {
+            DetailItem(label = "Server", value = it)
         }
+
+        // Content Type
+        httpResponseMetadata.contentType?.let {
+            DetailItem(label = "Content Type", value = it)
+        }
+
+        // Content Length
+        if (httpResponseMetadata.contentLength >= 0) {
+            DetailItem(
+                label = "Content Length",
+                value = formatBytes(httpResponseMetadata.contentLength),
+            )
+        }
+
+        // ETag (for cache validation)
+        httpResponseMetadata.etag?.let {
+            DetailItem(label = "ETag", value = it)
+        }
+
+        // Request ID (for server-side tracing)
+        httpResponseMetadata.requestId?.let {
+            DetailItem(label = "Request ID", value = it)
+        }
+
+        // Request Duration
+        if (httpResponseMetadata.requestDuration > 0) {
+            DetailItem(
+                label = "Request Duration",
+                value = "${httpResponseMetadata.requestDuration}ms",
+            )
+        }
+
+        // Timestamp
+        val dateFormat =
+            remember { SimpleDateFormat("MMM dd, yyyy hh:mm:ss.SSS a", Locale.getDefault()) }
+        val formattedTimestamp = dateFormat.format(Date(httpResponseMetadata.timestamp))
+        DetailItem(label = "Response Time", value = formattedTimestamp)
+
+        Spacer(modifier = Modifier.height(24.dp))
     }
 }
 
@@ -165,3 +173,52 @@ private fun formatBytes(bytes: Long): String =
         bytes < BYTES_IN_GB -> String.format(Locale.US, "%.2f MB", bytes / BYTES_IN_MB.toDouble())
         else -> String.format(Locale.US, "%.2f GB", bytes / BYTES_IN_GB.toDouble())
     }
+
+/**
+ * Previews for HttpResponseMetadataDisplay with different response scenarios
+ */
+@Preview(name = "HTTP Response Details - Full", showBackground = true)
+@Composable
+private fun PreviewHttpResponseMetadataDisplay() {
+    val sampleMetadata =
+        HttpResponseMetadata(
+            url = "https://trmnl.app/api/current_screen",
+            protocol = "h2",
+            statusCode = 200,
+            message = "OK",
+            contentType = "application/json; charset=utf-8",
+            contentLength = 317,
+            serverName = null,
+            requestDuration = 100,
+            etag = "W/\"3fa28fbc90b01b99c92466b34bc476d8\"",
+            requestId = "f064d019-0d34-4819-bef4-6132bbef4d8c",
+            timestamp = System.currentTimeMillis(),
+        )
+
+    TrmnlDisplayAppTheme {
+        HttpResponseMetadataDisplay(httpResponseMetadata = sampleMetadata)
+    }
+}
+
+@Preview(name = "HTTP Response Details - Minimal (Dark)", showBackground = true)
+@Composable
+private fun PreviewHttpResponseMetadataDisplayMinimal() {
+    val sampleMetadata =
+        HttpResponseMetadata(
+            url = "https://trmnl.app/api/current_screen",
+            protocol = "http/1.1",
+            statusCode = 304,
+            message = "Not Modified",
+            contentType = null,
+            contentLength = 0,
+            serverName = null,
+            requestDuration = 35,
+            etag = "W/\"3fa28fbc90b01b99c92466b34bc476d8\"",
+            requestId = null,
+            timestamp = System.currentTimeMillis(),
+        )
+
+    TrmnlDisplayAppTheme(darkTheme = true) {
+        HttpResponseMetadataDisplay(httpResponseMetadata = sampleMetadata)
+    }
+}


### PR DESCRIPTION
This pull request enhances the `HttpResponseDetailsBottomSheet` in the `app/src/main/java/ink/trmnl/android/ui/refreshlog/HttpResponseDetailsBottomSheet.kt` file by introducing a new composable function for displaying HTTP response metadata and adding previews for various response scenarios. It also includes minor formatting adjustments for improved readability.

### Enhancements to HTTP response metadata display:

* **New composable function for metadata display**: Introduced `HttpResponseMetadataDisplay`, a dedicated composable function to render HTTP response metadata within the bottom sheet.

* **Previews for different response scenarios**: Added two preview functions (`PreviewHttpResponseMetadataDisplay` and `PreviewHttpResponseMetadataDisplayMinimal`) to visualize the metadata display under different scenarios, including full and minimal details, with light and dark themes.

### Code readability improvements:

* **Reformatted `SimpleDateFormat` initialization**: Adjusted formatting for the `dateFormat` initialization to enhance code readability.