### PR TITLE
[ADDED] Support for BYOS device setup and display image compatibility

### DIFF
--- a/app/src/main/java/ink/trmnl/android/data/DeviceSetupInfo.kt
+++ b/app/src/main/java/ink/trmnl/android/data/DeviceSetupInfo.kt
@@ -1,0 +1,15 @@
+package ink.trmnl.android.data
+
+/**
+ * Represents the setup information for a TRMNL device.
+ *
+ * This data class is used to encapsulate the result of setting up a new device,
+ * including whether the setup was successful, the device's MAC ID, API key,
+ * and any relevant messages.
+ */
+data class DeviceSetupInfo(
+    val success: Boolean,
+    val deviceMacId: String,
+    val apiKey: String,
+    val message: String,
+)

--- a/app/src/main/java/ink/trmnl/android/data/TrmnlDisplayInfo.kt
+++ b/app/src/main/java/ink/trmnl/android/data/TrmnlDisplayInfo.kt
@@ -3,6 +3,7 @@ package ink.trmnl.android.data
 import androidx.annotation.Keep
 import ink.trmnl.android.data.AppConfig.DEFAULT_REFRESH_INTERVAL_SEC
 import ink.trmnl.android.model.TrmnlDeviceType
+import ink.trmnl.android.util.ERROR_TYPE_DEVICE_SETUP_REQUIRED
 import ink.trmnl.android.util.HTTP_200
 import ink.trmnl.android.util.HTTP_500
 import ink.trmnl.android.util.HTTP_OK
@@ -19,7 +20,14 @@ data class TrmnlDisplayInfo constructor(
     val status: Int,
     val trmnlDeviceType: TrmnlDeviceType,
     val imageUrl: String,
-    val imageName: String,
+    /**
+     * The file name of the image to be displayed.
+     *
+     * If this is an error type, it indicates a specific error condition.
+     * For example:
+     * - [ERROR_TYPE_DEVICE_SETUP_REQUIRED]
+     */
+    val imageFileName: String,
     val error: String? = null,
     val refreshIntervalSeconds: Long? = DEFAULT_REFRESH_INTERVAL_SEC,
     /**

--- a/app/src/main/java/ink/trmnl/android/model/TrmnlSetupResponse.kt
+++ b/app/src/main/java/ink/trmnl/android/model/TrmnlSetupResponse.kt
@@ -1,0 +1,31 @@
+package ink.trmnl.android.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Data class representing the response from the TRMNL setup API.
+ *
+ * Sample JSON response:
+ * ```json
+ * {
+ *     "api_key": "abc1234567890abcdef",
+ *     "friendly_id": "GO87665",
+ *     "image_url": "https://localhost:1234/assets/setup.bmp",
+ *     "message": "Welcome to Terminus!"
+ * }
+ * ```
+ *
+ * @property apiKey The API key for the device.
+ * @property friendlyId A user-friendly identifier for the device.
+ * @property imageUrl The URL of an image to display during setup.
+ * @property message A welcome message or setup instructions.
+ * @see ink.trmnl.android.network.TrmnlApiService.setupNewDevice
+ */
+@JsonClass(generateAdapter = true)
+data class TrmnlSetupResponse(
+    @Json(name = "api_key") val apiKey: String,
+    @Json(name = "friendly_id") val friendlyId: String,
+    @Json(name = "image_url") val imageUrl: String,
+    @Json(name = "message") val message: String,
+)

--- a/app/src/main/java/ink/trmnl/android/network/TrmnlApiService.kt
+++ b/app/src/main/java/ink/trmnl/android/network/TrmnlApiService.kt
@@ -2,6 +2,7 @@ package ink.trmnl.android.network
 
 import com.slack.eithernet.ApiResult
 import ink.trmnl.android.data.TrmnlDisplayRepository
+import ink.trmnl.android.model.TrmnlSetupResponse
 import ink.trmnl.android.network.model.TrmnlCurrentImageResponse
 import ink.trmnl.android.network.model.TrmnlDisplayResponse
 import retrofit2.http.GET
@@ -22,6 +23,8 @@ import retrofit2.http.Url
 interface TrmnlApiService {
     companion object {
         /**
+         * Path for the TRMNL API endpoint that provides the next image in a playlist.
+         *
          * https://docs.usetrmnl.com/go/private-api/fetch-screen-content#auto-advance-content
          *
          * @see getNextDisplayData
@@ -29,11 +32,20 @@ interface TrmnlApiService {
         internal const val NEXT_PLAYLIST_SCREEN_API_PATH = "api/display"
 
         /**
+         * Path for the TRMNL API endpoint that provides the current image in a playlist.
+         *
          * https://docs.usetrmnl.com/go/private-api/fetch-screen-content#current-screen
          *
          * @see getCurrentDisplayData
          */
         internal const val CURRENT_PLAYLIST_SCREEN_API_PATH = "api/current_screen"
+
+        /**
+         * Path for the TRMNL API endpoint used for new device setup.
+         *
+         * https://github.com/usetrmnl/byos_hanami?tab=readme-ov-file#setup-1
+         */
+        internal const val SETUP_API_PATH = "api/setup"
     }
 
     /**
@@ -68,4 +80,20 @@ interface TrmnlApiService {
         @Url fullApiUrl: String,
         @Header("access-token") accessToken: String,
     ): ApiResult<TrmnlCurrentImageResponse, Unit>
+
+    /**
+     * Setup a new TRMNL device using it's MAC ID. Using same API with same ID has no effect.
+     *
+     * This API is typically used once during the initial setup of a BYOS device.
+     * See https://github.com/usetrmnl/byos_hanami?tab=readme-ov-file#setup-1
+     *
+     * @param fullApiUrl The complete API URL to call (e.g., "https://your-server.com/api/setup").
+     * @param deviceMacId The device's MAC address, sent in the "ID" header.
+     * @return An [ApiResult] containing [TrmnlSetupResponse] on success.
+     */
+    @GET
+    suspend fun setupNewDevice(
+        @Url fullApiUrl: String,
+        @Header("ID") deviceMacId: String,
+    ): ApiResult<TrmnlSetupResponse, Unit>
 }

--- a/app/src/main/java/ink/trmnl/android/network/TrmnlApiService.kt
+++ b/app/src/main/java/ink/trmnl/android/network/TrmnlApiService.kt
@@ -10,7 +10,7 @@ import retrofit2.http.Header
 import retrofit2.http.Url
 
 /**
- * API service interface for TRMNL.
+ * API service interface for TRMNL or BYOS servers.
  *
  * This interface defines the endpoints for the TRMNL API.
  *
@@ -25,7 +25,8 @@ interface TrmnlApiService {
         /**
          * Path for the TRMNL API endpoint that provides the next image in a playlist.
          *
-         * https://docs.usetrmnl.com/go/private-api/fetch-screen-content#auto-advance-content
+         * - https://docs.usetrmnl.com/go/private-api/fetch-screen-content#auto-advance-content
+         * - https://github.com/usetrmnl/byos_hanami?tab=readme-ov-file#display
          *
          * @see getNextDisplayData
          */
@@ -44,8 +45,17 @@ interface TrmnlApiService {
          * Path for the TRMNL API endpoint used for new device setup.
          *
          * https://github.com/usetrmnl/byos_hanami?tab=readme-ov-file#setup-1
+         *
+         * @see setupNewDevice
          */
-        internal const val SETUP_API_PATH = "api/setup"
+        internal const val SETUP_API_PATH = "api/setup/"
+
+        /**
+         * Default content type for API requests.
+         *
+         * This is used when setting up a new device or making other API calls that require a content type header.
+         */
+        private const val DEFAULT_CONTENT_TYPE = "application/json"
     }
 
     /**
@@ -95,5 +105,6 @@ interface TrmnlApiService {
     suspend fun setupNewDevice(
         @Url fullApiUrl: String,
         @Header("ID") deviceMacId: String,
+        @Header("Content-Type") contentType: String = DEFAULT_CONTENT_TYPE,
     ): ApiResult<TrmnlSetupResponse, Unit>
 }

--- a/app/src/main/java/ink/trmnl/android/network/model/TrmnlDisplayResponse.kt
+++ b/app/src/main/java/ink/trmnl/android/network/model/TrmnlDisplayResponse.kt
@@ -64,7 +64,7 @@ data class TrmnlDisplayResponse(
      */
     val status: Int = HTTP_NONE,
     @Json(name = "image_url") val imageUrl: String?,
-    @Json(name = "filename") val imageName: String?,
+    @Json(name = "filename") val imageFileName: String?,
     @Json(name = "update_firmware") val updateFirmware: Boolean?,
     @Json(name = "firmware_url") val firmwareUrl: String?,
     @Json(name = "refresh_rate") val refreshRate: Long?,

--- a/app/src/main/java/ink/trmnl/android/network/model/TrmnlDisplayResponse.kt
+++ b/app/src/main/java/ink/trmnl/android/network/model/TrmnlDisplayResponse.kt
@@ -49,6 +49,17 @@ import ink.trmnl.android.util.HTTP_NONE
  *   "update_firmware": false
  * }
  * ```
+ *
+ * Sample 4404 response from BYOS Hanami server:
+ * ```json
+ * {
+ *   "type": "/problem_details#device_id",
+ *   "title": "Not Found",
+ *   "status": 404,
+ *   "detail": "Invalid device ID.",
+ *   "instance": "/api/display"
+ * }
+ * ```
  */
 @JsonClass(generateAdapter = true)
 data class TrmnlDisplayResponse(

--- a/app/src/main/java/ink/trmnl/android/ui/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/ui/settings/AppSettingsScreen.kt
@@ -464,7 +464,7 @@ class AppSettingsPresenter
                                     // Handle error response
                                     deviceSetupMessage = setupResult.message
                                 } else {
-                                    deviceSetupMessage = "Device setup successful! You can now use your TRMNL."
+                                    deviceSetupMessage = "Device setup successful! Re-validate ID/Token to continue."
                                     // Also prepopulate the access token
                                     accessToken = setupResult.apiKey
                                 }

--- a/app/src/main/java/ink/trmnl/android/util/NetworkExtensions.kt
+++ b/app/src/main/java/ink/trmnl/android/util/NetworkExtensions.kt
@@ -1,5 +1,7 @@
 package ink.trmnl.android.util
 
+import ink.trmnl.android.data.TrmnlDisplayInfo
+
 /**
  * 500 Internal Server Error - A generic error message, given when an unexpected
  * condition was encountered and no more specific message is suitable.
@@ -32,3 +34,12 @@ internal fun Int?.isHttpOk(): Boolean = this == HTTP_OK || this == HTTP_200 || t
  * Extension function to check if the HTTP status code is an error.
  */
 internal fun Int?.isHttpError(): Boolean = this == HTTP_500 || this == null
+
+/**
+ * Special error code provided in the [TrmnlDisplayInfo.imageName] as hack to indicate that the device requires setup.
+ *
+ * See following for additional context:
+ * - https://discord.com/channels/1281055965508141100/1331360842809348106/1384605617456545904
+ * - https://github.com/usetrmnl/trmnl-android/issues/83
+ */
+internal const val ERROR_TYPE_DEVICE_SETUP_REQUIRED = "device_requires_setup"

--- a/app/src/main/java/ink/trmnl/android/util/NetworkExtensions.kt
+++ b/app/src/main/java/ink/trmnl/android/util/NetworkExtensions.kt
@@ -36,7 +36,7 @@ internal fun Int?.isHttpOk(): Boolean = this == HTTP_OK || this == HTTP_200 || t
 internal fun Int?.isHttpError(): Boolean = this == HTTP_500 || this == null
 
 /**
- * Special error code provided in the [TrmnlDisplayInfo.imageName] as hack to indicate that the device requires setup.
+ * Special error code provided in the [TrmnlDisplayInfo.imageFileName] as hack to indicate that the device requires setup.
  *
  * See following for additional context:
  * - https://discord.com/channels/1281055965508141100/1331360842809348106/1384605617456545904

--- a/app/src/main/java/ink/trmnl/android/work/TrmnlImageRefreshWorker.kt
+++ b/app/src/main/java/ink/trmnl/android/work/TrmnlImageRefreshWorker.kt
@@ -118,7 +118,7 @@ class TrmnlImageRefreshWorker(
         refreshLogManager.addSuccessLog(
             trmnlDeviceType = deviceConfig.type,
             imageUrl = trmnlDisplayInfo.imageUrl,
-            imageName = trmnlDisplayInfo.imageName,
+            imageName = trmnlDisplayInfo.imageFileName,
             refreshIntervalSeconds = trmnlDisplayInfo.refreshIntervalSeconds,
             imageRefreshWorkType = workTypeValue,
             httpResponseMetadata = trmnlDisplayInfo.httpResponseMetadata,

--- a/app/src/test/java/ink/trmnl/android/data/TrmnlDisplayRepositoryTest.kt
+++ b/app/src/test/java/ink/trmnl/android/data/TrmnlDisplayRepositoryTest.kt
@@ -81,7 +81,7 @@ class TrmnlDisplayRepositoryTest {
                 TrmnlDisplayResponse(
                     status = 200,
                     imageUrl = "https://test.com/image.png",
-                    imageName = "test-image.png",
+                    imageFileName = "test-image.png",
                     refreshRate = 300L,
                     error = null,
                     updateFirmware = null,
@@ -122,7 +122,7 @@ class TrmnlDisplayRepositoryTest {
                 TrmnlDisplayResponse(
                     status = 500,
                     imageUrl = null,
-                    imageName = null,
+                    imageFileName = null,
                     refreshRate = null,
                     error = "Error fetching display",
                     updateFirmware = null,
@@ -341,7 +341,7 @@ class TrmnlDisplayRepositoryTest {
                 TrmnlDisplayResponse(
                     status = 200,
                     imageUrl = "https://test.com/image.png",
-                    imageName = "test-image.png",
+                    imageFileName = "test-image.png",
                     refreshRate = 300L,
                     error = null,
                     updateFirmware = null,
@@ -385,7 +385,7 @@ class TrmnlDisplayRepositoryTest {
                 TrmnlDisplayResponse(
                     status = 200,
                     imageUrl = "https://test.com/image.png",
-                    imageName = "test-image.png",
+                    imageFileName = "test-image.png",
                     refreshRate = 300L,
                     error = null,
                     updateFirmware = null,

--- a/app/src/test/java/ink/trmnl/android/data/TrmnlDisplayRepositoryTest.kt
+++ b/app/src/test/java/ink/trmnl/android/data/TrmnlDisplayRepositoryTest.kt
@@ -105,7 +105,7 @@ class TrmnlDisplayRepositoryTest {
             // Assert
             assertThat(result.status).isEqualTo(200)
             assertThat(result.imageUrl).isEqualTo("https://test.com/image.png")
-            assertThat(result.imageName).isEqualTo("test-image.png")
+            assertThat(result.imageFileName).isEqualTo("test-image.png")
             assertThat(result.refreshIntervalSeconds).isEqualTo(300L)
             assertThat(result.error).isNull()
             assertThat(result.trmnlDeviceType).isEqualTo(TrmnlDeviceType.TRMNL)
@@ -146,7 +146,7 @@ class TrmnlDisplayRepositoryTest {
             // Assert
             assertThat(result.status).isEqualTo(500)
             assertThat(result.imageUrl).isEmpty()
-            assertThat(result.imageName).isEmpty()
+            assertThat(result.imageFileName).isEmpty()
             assertThat(result.refreshIntervalSeconds).isNull()
             assertThat(result.error).isEqualTo("Error fetching display")
             assertThat(result.trmnlDeviceType).isEqualTo(TrmnlDeviceType.TRMNL)
@@ -184,7 +184,7 @@ class TrmnlDisplayRepositoryTest {
             // Assert
             assertThat(result.status).isEqualTo(200)
             assertThat(result.imageUrl).isEqualTo("https://test.com/current.png")
-            assertThat(result.imageName).isEqualTo("current-image.png")
+            assertThat(result.imageFileName).isEqualTo("current-image.png")
             assertThat(result.refreshIntervalSeconds).isEqualTo(600L)
             assertThat(result.error).isNull()
             assertThat(result.trmnlDeviceType).isEqualTo(TrmnlDeviceType.TRMNL)
@@ -222,7 +222,7 @@ class TrmnlDisplayRepositoryTest {
             // Assert
             assertThat(result.status).isEqualTo(500)
             assertThat(result.imageUrl).isEmpty()
-            assertThat(result.imageName).isEmpty()
+            assertThat(result.imageFileName).isEmpty()
             assertThat(result.refreshIntervalSeconds).isNull()
             assertThat(result.error).isEqualTo("Device not found")
             assertThat(result.trmnlDeviceType).isEqualTo(TrmnlDeviceType.TRMNL)
@@ -243,7 +243,7 @@ class TrmnlDisplayRepositoryTest {
             // Assert
             assertThat(result.status).isEqualTo(200)
             assertThat(result.imageUrl).contains("picsum.photos")
-            assertThat(result.imageName).contains("mocked-image-grayscale&time")
+            assertThat(result.imageFileName).contains("mocked-image-grayscale&time")
             assertThat(result.refreshIntervalSeconds).isEqualTo(600L)
             assertThat(result.error).isNull()
 
@@ -263,7 +263,7 @@ class TrmnlDisplayRepositoryTest {
             // Assert
             assertThat(result.status).isEqualTo(200)
             assertThat(result.imageUrl).contains("picsum.photos")
-            assertThat(result.imageName).contains("mocked-image-grayscale&time")
+            assertThat(result.imageFileName).contains("mocked-image-grayscale&time")
             assertThat(result.refreshIntervalSeconds).isEqualTo(600L)
             assertThat(result.error).isNull()
 

--- a/app/src/test/java/ink/trmnl/android/work/TrmnlImageRefreshWorkerTest.kt
+++ b/app/src/test/java/ink/trmnl/android/work/TrmnlImageRefreshWorkerTest.kt
@@ -139,7 +139,7 @@ class TrmnlImageRefreshWorkerTest {
                     status = HTTP_200,
                     trmnlDeviceType = TrmnlDeviceType.TRMNL,
                     imageUrl = validImageUrl,
-                    imageName = "test-image.png",
+                    imageFileName = "test-image.png",
                     refreshIntervalSeconds = validRefreshRate,
                 )
 
@@ -181,7 +181,7 @@ class TrmnlImageRefreshWorkerTest {
                     status = HTTP_200,
                     trmnlDeviceType = TrmnlDeviceType.BYOD,
                     imageUrl = validImageUrl,
-                    imageName = "test-image.png",
+                    imageFileName = "test-image.png",
                     refreshIntervalSeconds = validRefreshRate,
                 )
 
@@ -210,7 +210,7 @@ class TrmnlImageRefreshWorkerTest {
                     status = HTTP_200,
                     trmnlDeviceType = TrmnlDeviceType.BYOS,
                     imageUrl = validImageUrl,
-                    imageName = "test-image.png",
+                    imageFileName = "test-image.png",
                     refreshIntervalSeconds = validRefreshRate,
                 )
 
@@ -243,7 +243,7 @@ class TrmnlImageRefreshWorkerTest {
                     status = HTTP_200,
                     trmnlDeviceType = TrmnlDeviceType.TRMNL,
                     imageUrl = validImageUrl,
-                    imageName = "test-image.png",
+                    imageFileName = "test-image.png",
                     refreshIntervalSeconds = validRefreshRate,
                 )
 
@@ -270,7 +270,7 @@ class TrmnlImageRefreshWorkerTest {
                     status = HTTP_500,
                     trmnlDeviceType = TrmnlDeviceType.TRMNL,
                     imageUrl = "",
-                    imageName = "",
+                    imageFileName = "",
                     error = "Device not found",
                     refreshIntervalSeconds = null,
                 )
@@ -304,7 +304,7 @@ class TrmnlImageRefreshWorkerTest {
                     status = HTTP_200,
                     trmnlDeviceType = TrmnlDeviceType.TRMNL,
                     imageUrl = "",
-                    imageName = "",
+                    imageFileName = "",
                     refreshIntervalSeconds = validRefreshRate,
                 )
 
@@ -330,7 +330,7 @@ class TrmnlImageRefreshWorkerTest {
                     status = HTTP_200,
                     trmnlDeviceType = TrmnlDeviceType.TRMNL,
                     imageUrl = validImageUrl,
-                    imageName = "test-image.png",
+                    imageFileName = "test-image.png",
                     refreshIntervalSeconds = newRefreshRate,
                 )
 
@@ -357,7 +357,7 @@ class TrmnlImageRefreshWorkerTest {
                     status = HTTP_200,
                     trmnlDeviceType = TrmnlDeviceType.TRMNL,
                     imageUrl = validImageUrl,
-                    imageName = "test-image.png",
+                    imageFileName = "test-image.png",
                     refreshIntervalSeconds = validRefreshRate,
                 )
 
@@ -389,7 +389,7 @@ class TrmnlImageRefreshWorkerTest {
                     status = HTTP_200,
                     trmnlDeviceType = TrmnlDeviceType.TRMNL,
                     imageUrl = validImageUrl,
-                    imageName = "test-image.png",
+                    imageFileName = "test-image.png",
                     refreshIntervalSeconds = validRefreshRate,
                 )
 


### PR DESCRIPTION
Fixes #76 
Fixes #83 

----

This pull request introduces significant changes to support device setup functionality for BYOS devices and refactors existing data models for consistency. The most important updates include the addition of a new `DeviceSetupInfo` data class, modifications to handle device setup requirements in `TrmnlDisplayRepository`, and updates to API service and response models to accommodate the new setup workflow.

### Device Setup Functionality Enhancements:
* Added a new `DeviceSetupInfo` data class to encapsulate the result of the device setup process, including success status, device MAC ID, API key, and messages (`DeviceSetupInfo.kt`).
* Implemented `setupNewDevice` and `isDeviceSetupRequired` methods in `TrmnlDisplayRepository` to handle device setup logic, including API calls and response mapping (`TrmnlDisplayRepository.kt`). [[1]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62R162-R201) [[2]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62R336-R369)
* Added a `setupRequiredTrmnlDisplayInfo` helper method to create a `TrmnlDisplayInfo` object indicating that a device requires setup (`TrmnlDisplayRepository.kt`).

### API and Response Model Updates:
* Introduced a `TrmnlSetupResponse` data class to represent the response from the device setup API, including fields like `apiKey`, `friendlyId`, and `message` (`TrmnlSetupResponse.kt`).
* Updated `TrmnlApiService` to include the `setupNewDevice` API endpoint and added constants for setup-related paths (`TrmnlApiService.kt`).
* Modified `TrmnlDisplayResponse` to rename `imageName` to `imageFileName` for consistency with the new setup workflow (`TrmnlDisplayResponse.kt`).

### Refactoring and Code Cleanup:
* Replaced all occurrences of `imageName` with `imageFileName` in `TrmnlDisplayInfo` and related files for better clarity and alignment with API response fields (`TrmnlDisplayInfo.kt`, `TrmnlDisplayRepository.kt`). [[1]](diffhunk://#diff-05c39440088d6d4c47ffdf57478c980f7648d47f2a2cd615511baccc73f84127L22-R30) [[2]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62L69-R83) [[3]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62L135-R143)
* Disabled the `useBase64` logic temporarily in `TrmnlDisplayRepository` to address a known issue (`TrmnlDisplayRepository.kt`).

These changes collectively enhance the app's ability to handle device setup for BYOS devices while improving code clarity and alignment with API standards.