### PR TITLE
[ADDED] Minor code cleanup and docs

### DIFF
--- a/app/src/main/java/ink/trmnl/android/data/DeviceSetupInfo.kt
+++ b/app/src/main/java/ink/trmnl/android/data/DeviceSetupInfo.kt
@@ -3,6 +3,8 @@ package ink.trmnl.android.data
 /**
  * Represents the setup information for a TRMNL device.
  *
+ * See [TrmnlDisplayRepository.setupNewDevice] for more details.
+ *
  * This data class is used to encapsulate the result of setting up a new device,
  * including whether the setup was successful, the device's MAC ID, API key,
  * and any relevant messages.

--- a/app/src/main/java/ink/trmnl/android/data/TrmnlDisplayRepository.kt
+++ b/app/src/main/java/ink/trmnl/android/data/TrmnlDisplayRepository.kt
@@ -172,6 +172,11 @@ class TrmnlDisplayRepository
                 Timber.w("Device setup is only applicable for BYOS devices.")
             }
 
+            if (repositoryConfigProvider.shouldUseFakeData) {
+                // Avoid using real API in debug mode
+                return fakeTrmnlDeviceSetupInfo()
+            }
+
             val result =
                 apiService.setupNewDevice(
                     fullApiUrl = constructApiUrl(trmnlDeviceConfig.apiBaseUrl, TrmnlApiService.SETUP_API_PATH),
@@ -222,6 +227,19 @@ class TrmnlDisplayRepository
                 refreshIntervalSeconds = mockRefreshRate,
             )
         }
+
+        /**
+         * Generates fake setup info for debugging purposes without wasting an API request.
+         *
+         * ℹ️ This is only used when [RepositoryConfigProvider.shouldUseFakeData] is true.
+         */
+        private fun fakeTrmnlDeviceSetupInfo(): DeviceSetupInfo =
+            DeviceSetupInfo(
+                success = true,
+                deviceMacId = "A1:B2:C3:D4:E5:F6",
+                apiKey = "mocked-api-key-${System.currentTimeMillis()}",
+                message = "Mocked device setup successful",
+            )
 
         /**
          * Constructs the full URL for API requests based on the configured base URL for device.

--- a/app/src/main/java/ink/trmnl/android/data/TrmnlDisplayRepository.kt
+++ b/app/src/main/java/ink/trmnl/android/data/TrmnlDisplayRepository.kt
@@ -349,6 +349,12 @@ class TrmnlDisplayRepository
             trmnlDeviceConfig.type == TrmnlDeviceType.BYOS &&
                 response.imageFileName?.startsWith("setup", ignoreCase = true) == true &&
                 // This ensures that no screen is generated yet for the device
+                // Example (when device is not set up):
+                // -- "filename": "setup"
+                // -- "image_url": "/assets/setup-A2B2C2.svg"
+                // Example (when device is set up):
+                // -- "filename": "setup.png"
+                // -- "image_url": "https://my-trmnl-hub.com/assets/screens/ABCDEF123/setup.png",
                 response.imageUrl?.contains("screens", ignoreCase = true) == false
 
         /**

--- a/app/src/main/java/ink/trmnl/android/network/TrmnlApiService.kt
+++ b/app/src/main/java/ink/trmnl/android/network/TrmnlApiService.kt
@@ -2,9 +2,9 @@ package ink.trmnl.android.network
 
 import com.slack.eithernet.ApiResult
 import ink.trmnl.android.data.TrmnlDisplayRepository
-import ink.trmnl.android.model.TrmnlSetupResponse
 import ink.trmnl.android.network.model.TrmnlCurrentImageResponse
 import ink.trmnl.android.network.model.TrmnlDisplayResponse
+import ink.trmnl.android.network.model.TrmnlSetupResponse
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Headers

--- a/app/src/main/java/ink/trmnl/android/network/model/TrmnlSetupResponse.kt
+++ b/app/src/main/java/ink/trmnl/android/network/model/TrmnlSetupResponse.kt
@@ -1,4 +1,4 @@
-package ink.trmnl.android.model
+package ink.trmnl.android.network.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass

--- a/app/src/main/java/ink/trmnl/android/ui/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/ui/settings/AppSettingsScreen.kt
@@ -896,7 +896,7 @@ private fun DeviceTypeSelectorConfig(
                     value = deviceId,
                     onValueChange = onDeviceIdChanged,
                     label = { Text("Device ID (MAC Address)") },
-                    placeholder = { Text("aa:bb:cc:dd:ee:ff") },
+                    placeholder = { Text("A1:B2:C3:D4:E5:F6") },
                     isError = isDeviceMacIdError,
                     modifier =
                         Modifier
@@ -913,7 +913,7 @@ private fun DeviceTypeSelectorConfig(
                         if (isDeviceMacIdError && deviceIdError != null) {
                             Text(deviceIdError)
                         } else {
-                            Text("Optional: Used for Terminus server APIs")
+                            Text("Required: Used for Terminus server APIs")
                         }
                     },
                     trailingIcon = {


### PR DESCRIPTION
This pull request introduces enhancements to the device setup process, debugging capabilities, and code organization. Key changes include adding support for fake data in debug mode, improving documentation, and reorganizing the `TrmnlSetupResponse` model for better modularity.

### Enhancements to Device Setup and Debugging:

* Added a new `fakeTrmnlDeviceSetupInfo` method in `TrmnlDisplayRepository` to generate mock setup data when `RepositoryConfigProvider.shouldUseFakeData` is enabled. This avoids unnecessary API calls during debugging. [[1]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62R175-R179) [[2]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62R231-R243)
* Updated the placeholder for the MAC address in `AppSettingsScreen` to use a more realistic value (`A1:B2:C3:D4:E5:F6`) and clarified that the MAC address is required for Terminus server APIs. [[1]](diffhunk://#diff-608c9927f67a6112c5d39150db886046ede2bfa6e05d28cdaa2c826aaf6a2052L899-R899) [[2]](diffhunk://#diff-608c9927f67a6112c5d39150db886046ede2bfa6e05d28cdaa2c826aaf6a2052L916-R916)

### Documentation Improvements:

* Enhanced the `DeviceSetupInfo` class documentation by adding a reference to `TrmnlDisplayRepository.setupNewDevice` for better context.
* Added inline comments in `TrmnlDisplayRepository` to clarify the difference between setup states based on file names and URLs.

### Code Organization:

* Moved the `TrmnlSetupResponse` model from `ink.trmnl.android.model` to `ink.trmnl.android.network.model` for better alignment with its usage in network-related operations.
* Updated imports in `TrmnlApiService` to reflect the new location of `TrmnlSetupResponse`.