### PR TITLE
[REFACTOR] Moved fake communication and network tools to separate files

### DIFF
--- a/app/src/main/java/ink/trmnl/android/data/TrmnlDisplayRepository.kt
+++ b/app/src/main/java/ink/trmnl/android/data/TrmnlDisplayRepository.kt
@@ -229,63 +229,20 @@ class TrmnlDisplayRepository
             trmnlDeviceConfig: TrmnlDeviceConfig,
             failure: ApiResult.Failure<Unit>,
         ): TrmnlDisplayInfo =
-            when (failure) {
-                /**
-                 * Handles API-specific failures, returning a [TrmnlDisplayInfo] with a generic API failure message.
-                 */
-                is ApiResult.Failure.ApiFailure -> {
-                    TrmnlDisplayInfo(
-                        status = HTTP_500,
-                        trmnlDeviceType = trmnlDeviceConfig.type,
-                        imageUrl = "",
-                        imageFileName = "",
-                        error = "API failure",
-                        refreshIntervalSeconds = 0L,
-                    )
-                }
-
-                /**
-                 * Handles HTTP failures, including the HTTP status code and error message in the result.
-                 */
-                is ApiResult.Failure.HttpFailure -> {
-                    TrmnlDisplayInfo(
-                        status = HTTP_500,
-                        trmnlDeviceType = trmnlDeviceConfig.type,
-                        imageUrl = "",
-                        imageFileName = "",
-                        error = "HTTP failure: ${failure.code}, error: ${failure.error}",
-                        refreshIntervalSeconds = 0L,
-                    )
-                }
-
-                /**
-                 * Handles network-related failures, including the localized error message in the result.
-                 */
-                is ApiResult.Failure.NetworkFailure -> {
-                    TrmnlDisplayInfo(
-                        status = HTTP_500,
-                        trmnlDeviceType = trmnlDeviceConfig.type,
-                        imageUrl = "",
-                        imageFileName = "",
-                        error = "Network failure: ${failure.error.localizedMessage}",
-                        refreshIntervalSeconds = 0L,
-                    )
-                }
-
-                /**
-                 * Handles unknown failures, including the localized error message in the result.
-                 */
-                is ApiResult.Failure.UnknownFailure -> {
-                    TrmnlDisplayInfo(
-                        status = HTTP_500,
-                        trmnlDeviceType = trmnlDeviceConfig.type,
-                        imageUrl = "",
-                        imageFileName = "",
-                        error = "Unknown failure: ${failure.error.localizedMessage}",
-                        refreshIntervalSeconds = 0L,
-                    )
-                }
-            }
+            TrmnlDisplayInfo(
+                status = HTTP_500,
+                trmnlDeviceType = trmnlDeviceConfig.type,
+                imageUrl = "",
+                imageFileName = "",
+                error =
+                    when (failure) {
+                        is ApiResult.Failure.ApiFailure -> "API request failed to process response"
+                        is ApiResult.Failure.HttpFailure -> "HTTP failure: ${failure.code}, error: ${failure.error}"
+                        is ApiResult.Failure.NetworkFailure -> "Network failure: ${failure.error.localizedMessage}"
+                        is ApiResult.Failure.UnknownFailure -> "Unknown failure: ${failure.error.localizedMessage}"
+                    },
+                refreshIntervalSeconds = 0L,
+            )
 
         /**
          * Right now there is no good known way to determine if a device requires setup.

--- a/app/src/main/java/ink/trmnl/android/data/fake/FakeNetworkCommunication.kt
+++ b/app/src/main/java/ink/trmnl/android/data/fake/FakeNetworkCommunication.kt
@@ -1,0 +1,52 @@
+package ink.trmnl.android.data.fake
+
+import ink.trmnl.android.data.DeviceSetupInfo
+import ink.trmnl.android.data.ImageMetadataStore
+import ink.trmnl.android.data.RepositoryConfigProvider
+import ink.trmnl.android.data.TrmnlDisplayInfo
+import ink.trmnl.android.model.TrmnlDeviceType
+import ink.trmnl.android.util.HTTP_200
+import timber.log.Timber
+
+// Contains fake implementations of network communication for local development
+// and testing without depending on real servers.
+
+/**
+ * Generates fake display info for debugging purposes without wasting an API request.
+ *
+ * ℹ️ This is only used when [RepositoryConfigProvider.shouldUseFakeData] is true.
+ */
+internal suspend fun generateFakeTrmnlDisplayInfo(
+    imageMetadataStore: ImageMetadataStore,
+    apiUsed: String,
+): TrmnlDisplayInfo {
+    Timber.d("DEBUG: Using mock data for display info")
+    val timestampMin = System.currentTimeMillis() / 60_000 // Changes every minute
+    val mockImageUrl = "https://picsum.photos/300/200?grayscale&time=$timestampMin&api=$apiUsed"
+    val mockRefreshRate = 600L
+
+    // Save mock data to the data store
+    imageMetadataStore.saveImageMetadata(mockImageUrl, mockRefreshRate)
+
+    return TrmnlDisplayInfo(
+        status = HTTP_200,
+        trmnlDeviceType = TrmnlDeviceType.TRMNL,
+        imageUrl = mockImageUrl,
+        imageFileName = "mocked-image-" + mockImageUrl.substringAfterLast('?'),
+        error = null,
+        refreshIntervalSeconds = mockRefreshRate,
+    )
+}
+
+/**
+ * Generates fake setup info for debugging purposes without wasting an API request.
+ *
+ * ℹ️ This is only used when [RepositoryConfigProvider.shouldUseFakeData] is true.
+ */
+internal fun generateFakeDeviceSetupInfo(): DeviceSetupInfo =
+    DeviceSetupInfo(
+        success = true,
+        deviceMacId = "A1:B2:C3:D4:E5:F6",
+        apiKey = "mocked-api-key-${System.currentTimeMillis()}",
+        message = "Mocked device setup successful",
+    )

--- a/app/src/main/java/ink/trmnl/android/network/util/ApiResultTools.kt
+++ b/app/src/main/java/ink/trmnl/android/network/util/ApiResultTools.kt
@@ -1,0 +1,34 @@
+package ink.trmnl.android.network.util
+
+import com.slack.eithernet.ApiResult
+import com.slack.eithernet.InternalEitherNetApi
+import ink.trmnl.android.data.HttpResponseMetadata
+
+/**
+ * Extracts HTTP response metadata from an ApiResult.Success instance.
+ * The metadata is retrieved from the okhttp3.Response object stored in the ApiResult's tags.
+ *
+ * @param apiResult The successful API result containing response metadata
+ * @return HttpResponseMetadata object containing useful response information, or null if not available
+ */
+@OptIn(InternalEitherNetApi::class)
+internal fun extractHttpResponseMetadata(apiResult: ApiResult.Success<*>): HttpResponseMetadata? {
+    val httpResponse = apiResult.tags[okhttp3.Response::class] as? okhttp3.Response ?: return null
+
+    // Calculate the request duration using the timestamps from the response
+    val requestDuration = httpResponse.receivedResponseAtMillis - httpResponse.sentRequestAtMillis
+
+    return HttpResponseMetadata(
+        url = httpResponse.request.url.toString(),
+        protocol = httpResponse.protocol.toString(),
+        statusCode = httpResponse.code,
+        message = httpResponse.message,
+        contentType = httpResponse.header("Content-Type"),
+        contentLength = httpResponse.header("Content-Length")?.toLongOrNull() ?: -1,
+        serverName = httpResponse.header("Server"),
+        requestDuration = requestDuration,
+        etag = httpResponse.header("etag"),
+        requestId = httpResponse.header("x-request-id"),
+        timestamp = System.currentTimeMillis(),
+    )
+}


### PR DESCRIPTION
Fixes #92

This pull request refactors the `TrmnlDisplayRepository` class by extracting fake data generation logic and HTTP response metadata extraction into separate utility files. It also simplifies error handling for API failures and removes redundant code. These changes improve code modularity, readability, and maintainability.

### Refactoring and Code Extraction:

* Moved fake data generation logic (`fakeTrmnlDisplayInfo` and `fakeTrmnlDeviceSetupInfo`) to a new utility file `FakeNetworkCommunication.kt` as `generateFakeTrmnlDisplayInfo` and `generateFakeDeviceSetupInfo`, respectively. (`[[1]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62L207-L243)`, `[[2]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62L177-R178)`, `[[3]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62L121-R122)`, `[[4]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62L51-R52)`, `[[5]](diffhunk://#diff-a1dc3728807dc5f3cd9d8a36ce602dcc2e2820b1bebe9f5aad97c56a9cd97313R1-R52)`)
* Extracted HTTP response metadata extraction logic into a new utility file `ApiResultTools.kt` as `extractHttpResponseMetadata`. (`[[1]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62L268-L353)`, `[[2]](diffhunk://#diff-816cec5bbacf892c4f8a7b5c72ca15dbaaab1868b7a3cbb428be46ce158ae2b0R1-R34)`)

### Simplification of Error Handling:

* Consolidated error handling for API failures into a single `when` block, reducing redundancy and improving clarity. (`[app/src/main/java/ink/trmnl/android/data/TrmnlDisplayRepository.ktL268-L353](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62L268-L353)`)

### Code Cleanup:

* Removed unused imports and redundant methods, such as `fakeTrmnlDisplayInfo` and `fakeTrmnlDeviceSetupInfo`, from `TrmnlDisplayRepository.kt`. (`[[1]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62L207-L243)`, `[[2]](diffhunk://#diff-fcd4b71a224d48e08d4ea36685e50a2bbdef546d82d03387f1e6446f1f74df62L268-L353)`)