### PR TITLE
[ADDED] Allow non-secure HTTP based BYOS URL

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.App"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="35"
         android:enableOnBackInvokedCallback="true"
         tools:replace="android:appComponentFactory">

--- a/app/src/main/java/ink/trmnl/android/util/InputValidator.kt
+++ b/app/src/main/java/ink/trmnl/android/util/InputValidator.kt
@@ -3,22 +3,22 @@ package ink.trmnl.android.util
 import java.util.regex.Pattern
 
 /**
- * Validates if the provided string is a valid HTTPS URL.
+ * Validates if the provided string is a valid HTTP or HTTPS URL.
  *
  * The function checks that the URL:
- * - Starts with https:// (HTTP is not accepted for security reasons)
+ * - Starts with http:// or https://
  * - Contains valid URL characters in the domain and path components
  *
  * @param url The string to validate as a URL
- * @return true if the string is a valid HTTPS URL, false otherwise
+ * @return true if the string is a valid HTTP or HTTPS URL, false otherwise
  */
 internal fun isValidUrl(url: String): Boolean {
-    val httpsRegex =
+    val httpRegex =
         Pattern.compile(
-            "^(https)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]",
+            "^(http|https)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]",
             Pattern.CASE_INSENSITIVE,
         )
-    return httpsRegex.matcher(url).matches()
+    return httpRegex.matcher(url).matches()
 }
 
 /**

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Allow cleartext traffic for all domains -->
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+
+    <!-- Specific configuration for localhost/emulator addresses -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">127.0.0.1</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain> <!-- Android emulator's localhost -->
+    </domain-config>
+</network-security-config>

--- a/app/src/test/java/ink/trmnl/android/util/InputValidatorTest.kt
+++ b/app/src/test/java/ink/trmnl/android/util/InputValidatorTest.kt
@@ -8,9 +8,10 @@ import org.junit.Test
  */
 class InputValidatorTest {
     @Test
-    fun `isValidUrl should return true for valid HTTPS URLs`() {
+    fun `isValidUrl should return true for valid HTTP and HTTPS URLs`() {
         val validUrls =
             listOf(
+                // HTTPS URLs
                 "https://localhost:2443",
                 "https://example.com",
                 "https://example.com/path",
@@ -21,6 +22,16 @@ class InputValidatorTest {
                 "https://example.com/path/to/resource",
                 "https://example.com/path-with-dash",
                 "https://example.com/path_with_underscore",
+                // HTTP URLs
+                "http://example.com",
+                "http://localhost",
+                "http://localhost:8080",
+                "http://subdomain.example.com",
+                "http://example.com/path",
+                "http://example.com/path?query=value&another=true",
+                "http://127.0.0.1",
+                "http://10.0.2.2",
+                "http://example-domain.com:9000/api",
             )
 
         validUrls.forEach { url ->
@@ -29,15 +40,12 @@ class InputValidatorTest {
     }
 
     @Test
-    fun `isValidUrl should return false for invalid URLs and HTTP URLs`() {
+    fun `isValidUrl should return false for invalid URLs`() {
         val invalidUrls =
             listOf(
                 "",
                 "example.com",
                 "www.example.com",
-                "http://example.com", // HTTP is now invalid - HTTPS only
-                "http://subdomain.example.com", // HTTP is now invalid - HTTPS only
-                "http://example.com/path", // HTTP is now invalid - HTTPS only
                 "ftp://example.com",
                 "file:///path/to/file",
                 "http:/example.com",


### PR DESCRIPTION
Fixes #96
Fixes #45

![Image](https://github.com/user-attachments/assets/73101d95-8575-4dbe-99ba-b50d9c62a06c)

This pull request introduces changes to enhance network configuration and URL validation in the Android application. The most important updates include adding a network security configuration to allow cleartext traffic for specific domains and updating the URL validation logic to accept both HTTP and HTTPS URLs.

### Network Configuration Updates:
* [`app/src/main/AndroidManifest.xml`](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR17): Added the `android:networkSecurityConfig` attribute to reference the new network security configuration file.
* [`app/src/main/res/xml/network_security_config.xml`](diffhunk://#diff-8893c8c1bc054883fb186e7abd95c164cb46d04e324e08614f856c59ff9bdb3bR1-R16): Created a new network security configuration file to permit cleartext traffic for all domains and provide specific configurations for localhost/emulator addresses.

### URL Validation Enhancements:
* [`app/src/main/java/ink/trmnl/android/util/InputValidator.kt`](diffhunk://#diff-b69e5e0ce979a5de6940350d9b8d26af2eae206d783648faa5f742477241ed11L6-R21): Updated the `isValidUrl` function to validate both HTTP and HTTPS URLs instead of only HTTPS URLs. Adjusted the regex pattern and documentation accordingly.