### PR TITLE
[FIXED] Gradle task name issue for F-Droid

### DIFF
--- a/metadata/ink.trmnl.android.yml
+++ b/metadata/ink.trmnl.android.yml
@@ -42,7 +42,8 @@ Builds:
     commit: v1.9.1
     subdir: app
     gradle:
-      - assembleFdroidRelease
+      # F-droid build will append assemble to run: `assembleFdroidRelease`
+      - fdroidRelease
     # app/build/outputs/apk/fdroid/release/app-fdroid-release-unsigned.apk
     output: build/outputs/apk/fdroid/release/app-fdroid-release-unsigned.apk
 


### PR DESCRIPTION
Fixes

```
FAILURE: Build failed with an exception.
* What went wrong:
Task 'assembleAssembleFdroidReleaseRelease' not found in project ':app'.
* Try:
> Run gradle tasks to get a list of available tasks.
> For more on name expansion, please refer to https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:name_abbreviation in the Gradle documentation.
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
```

https://gitlab.com/fdroid/fdroiddata/-/merge_requests/24134