### PR TITLE
[CLEANUP] Readme and other docs

### DIFF
--- a/BUILD_FDROID.md
+++ b/BUILD_FDROID.md
@@ -9,6 +9,7 @@ The app includes specific configurations for F-Droid compatibility:
 1. A dedicated `fdroid` product flavor that excludes Google Fonts
 2. A specific `fdroidRelease` build type 
 3. System fonts are used instead of Google Fonts for the F-Droid version
+4. The F-Droid build is **not signed** (as per [PR #106](https://github.com/usetrmnl/trmnl-android/pull/106)) - F-Droid handles the signing process
 
 ## Building the F-Droid Version
 
@@ -18,7 +19,7 @@ To build the F-Droid version locally:
 ./gradlew assembleFdroidRelease
 ```
 
-This will generate an APK in `app/build/outputs/apk/fdroid/release/` that is suitable for F-Droid.
+This will generate an unsigned APK in `app/build/outputs/apk/fdroid/release/` that is suitable for F-Droid submission. Unlike the standard release build, the F-Droid build variant does not have a signing configuration, as F-Droid's build system will handle the signing process.
 
 Alternatively, you can use the convenience task:
 
@@ -56,3 +57,5 @@ Ensure the following are available:
 - The app is licensed under the MIT license
 - F-Droid metadata is complete
 - The app builds successfully with the F-Droid build system
+
+Note that F-Droid will build and sign the app themselves using their own signing key. Our build process intentionally does not include a signing configuration for the F-Droid variant (as implemented in [PR #106](https://github.com/usetrmnl/trmnl-android/pull/106)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,14 @@ To build specific variants:
 ./gradlew buildAllFlavors
 ```
 
+For more details on the F-Droid build process, see [BUILD_FDROID.md](BUILD_FDROID.md). App! This document provides guidelines and instructions to help you contribute effectively.
+
+
+### Release Process
+
+For instructions on creating new releases and managing versions across the project, see the [Release Checklist](RELEASE_CHECKLIST.md).
+
+
 ### Snapshot Builds
 Automatic snapshot release builds are available in the [release workflow](https://github.com/usetrmnl/trmnl-android/actions/workflows/android-release.yml) artifacts.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ To build specific variants:
 ./gradlew buildAllFlavors
 ```
 
-For more details on the F-Droid build process, see [BUILD_FDROID.md](BUILD_FDROID.md). App! This document provides guidelines and instructions to help you contribute effectively.
+For more details on the F-Droid build process, see [BUILD_FDROID.md](BUILD_FDROID.md). This document provides guidelines and instructions to help you contribute effectively.
 
 
 ### Release Process

--- a/README.md
+++ b/README.md
@@ -55,10 +55,6 @@ The app will *soon* be available on F-Droid, providing a free and open source An
 ## <img src="project-resources/logo/android-logo-head.svg" width="60" alt="android logo"/>Android Development & Contribution Guide
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more details on how to get started and contribute to the project.
 
-### Release Process
-
-For instructions on creating new releases and managing versions across the project, see the [Release Checklist](RELEASE_CHECKLIST.md).
-
 ---
 
 ## Related References 📖

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,13 +14,22 @@ android {
     compileSdk = 35
 
     defaultConfig {
+        // The application ID is the unique identifier for the app on the Play Store and other app stores.
         applicationId = "ink.trmnl.android"
+        
         // Minimum SDK is Android 9.0 (Pie) with 94% Android devices coverage
         // Can't be lower than 28, See https://github.com/usetrmnl/trmnl-android/pull/56
         minSdk = 28
-        targetSdk = 35
-        versionCode = 15 // Also update `metadata/ink.trmnl.android.yml`
-        versionName = "1.9.4" // Also update `metadata/ink.trmnl.android.yml`
+
+        // See https://apilevels.com/
+        targetSdk = 35 // Android 15.0 (Vanilla Ice Cream)
+        
+        // App versioning is scattered across multiple files.
+        // 👇🏽 Use the following workflow to update versions everywhere automatically ♻️
+        // https://github.com/usetrmnl/trmnl-android/actions/workflows/version-management.yml
+        versionCode = 15
+        versionName = "1.9.4"
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
This pull request focuses on updates to documentation and build configurations to improve clarity and compatibility for F-Droid builds. Key changes include adjustments to the `BUILD_FDROID.md` file, updates to `CONTRIBUTING.md` and `README.md`, and enhancements in `app/build.gradle.kts` for better version management.

### Documentation Updates for F-Droid Compatibility:

* [`BUILD_FDROID.md`](diffhunk://#diff-d5b15b3886e7c8a63d8153b688880d98cfa6f64fca93cf8cd09da4700b46ad16R12): Added details clarifying that the F-Droid build is unsigned and relies on F-Droid's signing process, including updates to the build instructions and prerequisites. [[1]](diffhunk://#diff-d5b15b3886e7c8a63d8153b688880d98cfa6f64fca93cf8cd09da4700b46ad16R12) [[2]](diffhunk://#diff-d5b15b3886e7c8a63d8153b688880d98cfa6f64fca93cf8cd09da4700b46ad16L21-R22) [[3]](diffhunk://#diff-d5b15b3886e7c8a63d8153b688880d98cfa6f64fca93cf8cd09da4700b46ad16R60-R61)
* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R91-R98): Included a reference to `BUILD_FDROID.md` for contributors interested in F-Droid builds and added a new section for release process instructions.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-L61): Removed the outdated "Release Process" section, as it is now covered in `CONTRIBUTING.md`.

### Build Configuration Enhancements:

* [`app/build.gradle.kts`](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R17-R32): Improved comments for clarity on application ID, SDK levels, and versioning workflow. Added references to automated version management actions for consistency across files.