### PR TITLE
[ADDED] Test workflow to check the keystore file configs

### DIFF
--- a/.github/workflows/test-keystore.yml
+++ b/.github/workflows/test-keystore.yml
@@ -1,0 +1,153 @@
+name: Test Keystore Configuration
+
+# This workflow is solely for testing that the keystore configuration works
+# It can be triggered manually to verify that:
+# 1. The base64 keystore decodes properly
+# 2. The keystore password works
+# 3. The key alias exists in the keystore
+# 4. The key password works
+
+on:
+  # Manual trigger only - run this to test your keystore configuration
+  workflow_dispatch:
+
+jobs:
+  test-keystore:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'  # Using a stable JDK version
+          distribution: 'temurin'
+      
+      - name: Verify Java and Keytool Installation
+        run: |
+          echo "Java version:"
+          java -version
+          
+          echo "Keytool version:"
+          keytool -help | head -n 1
+
+      - name: Create Test Directory
+        run: mkdir -p keystore-test
+      
+      - name: Check KEYSTORE_BASE64 Secret Length
+        run: |
+          if [[ -n "${{ secrets.KEYSTORE_BASE64 }}" ]]; then
+            SECRET_LENGTH=$(echo "${{ secrets.KEYSTORE_BASE64 }}" | wc -c)
+            echo "✅ KEYSTORE_BASE64 secret is set (length: $SECRET_LENGTH chars)"
+          else
+            echo "❌ KEYSTORE_BASE64 secret is not set"
+            exit 1
+          fi
+      
+      - name: Decode Keystore
+        run: |
+          # Decode the base64 keystore to a file
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > keystore-test/release.keystore
+          
+          # Check if the file was created and has content
+          if [ -s keystore-test/release.keystore ]; then
+            echo "✅ Keystore decoded successfully"
+            echo "File size: $(wc -c < keystore-test/release.keystore) bytes"
+            echo "File details:"
+            ls -la keystore-test/release.keystore
+            
+            # Check file type
+            file keystore-test/release.keystore
+            
+            # Show first few bytes as hex (for debugging)
+            echo "First 32 bytes as hex:"
+            hexdump -C -n 32 keystore-test/release.keystore
+          else
+            echo "❌ Keystore file is empty or not created properly"
+            exit 1
+          fi
+      
+      - name: Test Keystore with Password
+        run: |
+          echo "Testing keystore with provided password..."
+          keytool -list -keystore keystore-test/release.keystore -storepass "${{ secrets.KEYSTORE_PASSWORD }}" > keystore-test/output.txt 2>&1 || true
+          
+          if grep -q "Keystore type:" keystore-test/output.txt; then
+            echo "✅ Keystore password is correct"
+            cat keystore-test/output.txt
+          else
+            echo "❌ Keystore password is incorrect or keystore format is invalid"
+            echo "Error output:"
+            cat keystore-test/output.txt
+            
+            # Try common default passwords
+            echo "Trying with empty password..."
+            keytool -list -keystore keystore-test/release.keystore -storepass "" > keystore-test/empty.txt 2>&1 || true
+            
+            if grep -q "Keystore type:" keystore-test/empty.txt; then
+              echo "✅ Keystore works with EMPTY password"
+            else
+              echo "❌ Empty password doesn't work either"
+            fi
+            
+            echo "Trying with 'android' as password..."
+            keytool -list -keystore keystore-test/release.keystore -storepass "android" > keystore-test/android.txt 2>&1 || true
+            
+            if grep -q "Keystore type:" keystore-test/android.txt; then
+              echo "✅ Keystore works with 'android' as password"
+            else
+              echo "❌ 'android' password doesn't work either"
+            fi
+          fi
+
+      - name: Test Key Alias
+        if: always()  # Run even if previous steps failed
+        run: |
+          echo "Testing key alias..."
+          keytool -list -keystore keystore-test/release.keystore -storepass "${{ secrets.KEYSTORE_PASSWORD }}" -alias "${{ secrets.KEY_ALIAS }}" > keystore-test/alias.txt 2>&1 || true
+          
+          if grep -q "Alias name:" keystore-test/alias.txt; then
+            echo "✅ Key alias exists in the keystore"
+            cat keystore-test/alias.txt
+          else
+            echo "❌ Key alias does not exist in the keystore or other error"
+            echo "Error output:"
+            cat keystore-test/alias.txt
+            
+            echo "Available aliases in the keystore (if any):"
+            keytool -list -keystore keystore-test/release.keystore -storepass "${{ secrets.KEYSTORE_PASSWORD }}" 2>/dev/null | grep -i "alias" || echo "Could not list aliases"
+          fi
+
+      - name: Test Different Store Types
+        if: always()  # Run even if previous steps failed
+        run: |
+          echo "Testing with different keystore types..."
+          for type in "JKS" "PKCS12" "JCEKS"; do
+            echo "Testing with store type: $type"
+            keytool -list -keystore keystore-test/release.keystore -storetype $type -storepass "${{ secrets.KEYSTORE_PASSWORD }}" > keystore-test/storetype-$type.txt 2>&1 || true
+            
+            if grep -q "Keystore type:" keystore-test/storetype-$type.txt; then
+              echo "✅ Keystore works with type $type"
+              cat keystore-test/storetype-$type.txt | head -5
+            else
+              echo "❌ Keystore does not work with type $type"
+            fi
+          done
+
+      - name: Create Test Keystore (Sanity Check)
+        if: always()  # Run even if previous steps failed
+        run: |
+          echo "Creating a test keystore to verify keytool is working correctly..."
+          keytool -genkey -v -keystore keystore-test/debug.keystore -storepass android -keypass android -alias androiddebugkey -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"
+          
+          echo "Testing the newly created keystore:"
+          keytool -list -keystore keystore-test/debug.keystore -storepass android
+
+      - name: Upload Diagnostic Files
+        if: always()  # Run even if previous steps failed
+        uses: actions/upload-artifact@v4
+        with:
+          name: keystore-diagnostic-files
+          path: keystore-test/
+          retention-days: 1  # Only keep for a day since it contains diagnostic info

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ google-services.json
 app/debug/
 app/release/
 *.salive
+app*.aab


### PR DESCRIPTION
Since the signing key is not working I have reverted everything.

Let's build a test github workflow that only makes use of following config:

| Secret Name         | Value                                    |
| ------------------- | ---------------------------------------- |
| `KEYSTORE_BASE64`   | Contents of `release.keystore.base64`    |
| `KEYSTORE_PASSWORD` | Your keystore password                   |
| `KEY_ALIAS`         | The alias you used (e.g., `release_key`) |
| `KEY_PASSWORD`      | The key password                         |

I just want to make sure the key is decoded right and the keytool can read and display the info using the password and alias.

Make sure the workflow can be manually run so that I can update these secrets and try out to see the output.