### PR TITLE
[ADDED] More debugging for the release key

### DIFF
--- a/.github/workflows/test-keystore.yml
+++ b/.github/workflows/test-keystore.yml
@@ -68,6 +68,28 @@ jobs:
             exit 1
           fi
       
+      - name: Dump Keystore Information
+        if: always()  # Run even if previous steps failed
+        run: |
+          echo "Dumping keystore information (with sensitive data redacted)..."
+          
+          # List all entries without showing certificates
+          echo "All keystore entries:"
+          keytool -list -keystore keystore-test/release.keystore -storepass "${{ secrets.KEYSTORE_PASSWORD }}" | grep -v "Certificate fingerprint"
+          
+          # Try to extract aliases
+          echo "Attempting to extract aliases:"
+          keytool -list -keystore keystore-test/release.keystore -storepass "${{ secrets.KEYSTORE_PASSWORD }}" | grep -E ',[^,]+, PrivateKeyEntry' | sed 's/,.*//' || echo "No aliases could be extracted"
+          
+          # Check if the configured alias exists
+          echo "Checking if configured alias exists:"
+          keytool -list -keystore keystore-test/release.keystore -storepass "${{ secrets.KEYSTORE_PASSWORD }}" -alias "${{ secrets.KEY_ALIAS }}" > /dev/null 2>&1
+          if [ $? -eq 0 ]; then
+            echo "✅ Alias '${{ secrets.KEY_ALIAS }}' exists in keystore"
+          else
+            echo "❌ Alias '${{ secrets.KEY_ALIAS }}' NOT found in keystore"
+          fi
+
       - name: Test Keystore with Password
         run: |
           echo "Testing keystore with provided password..."


### PR DESCRIPTION
This pull request adds a new step to the `jobs:` section of the `.github/workflows/test-keystore.yml` file. The step is designed to dump keystore information for debugging purposes, while ensuring sensitive data is redacted.

### Debugging enhancements:

* **Dump Keystore Information step**: Added a new step that runs regardless of previous step failures (`if: always()`). This step includes commands to:
  - List all keystore entries without showing certificates.
  - Attempt to extract aliases from the keystore.
  - Check if a configured alias exists in the keystore, providing clear success or failure messages.