### PR TITLE
[MINOR] Fixes

### DIFF
--- a/.github/workflows/test-keystore.yml
+++ b/.github/workflows/test-keystore.yml
@@ -124,12 +124,13 @@ jobs:
           fi
 
       - name: Test Key Alias
-        if: always()  # Run even if previous steps failed
+        if: always()
         run: |
           echo "Testing key alias..."
           keytool -list -keystore keystore-test/release.keystore -storepass "${{ secrets.KEYSTORE_PASSWORD }}" -alias "${{ secrets.KEY_ALIAS }}" > keystore-test/alias.txt 2>&1 || true
           
-          if grep -q "Alias name:" keystore-test/alias.txt; then
+          # Check success by looking for the certificate fingerprint instead of "Alias name:"
+          if grep -q "PrivateKeyEntry" keystore-test/alias.txt; then
             echo "✅ Key alias exists in the keystore"
             cat keystore-test/alias.txt
           else


### PR DESCRIPTION
Great news! The debug output now provides much more clarity about what's happening with your keystore. Let's analyze the results:

### What's Working:
1. ✅ **Keystore is successfully decoded** (2740 bytes)
2. ✅ **Keystore password is correct** (works with your secret)
3. ✅ **Keystore works with both JKS and PKCS12 formats**
4. ✅ **Your keystore contains 1 entry** as expected
5. ✅ **The configured alias exists in the keystore** (confirmed with special check)

### The Confusion:
The only contradiction seems to be between these two messages:
```
✅ Alias '***' exists in keystore
```
and
```
❌ Key alias does not exist in the keystore or other error
```

Looking at the detailed output, we can see this in the "Error output" section:
```
***, Jun 28, 2025, PrivateKeyEntry,
Certificate fingerprint (SHA-256): 20:9B:92:F5:BB:01:44:23:72:51:A1:0F:C3:EB:B5:3A:11:17:E3:DF:EB:40:69:97:BF:D6:B0:7F:6F:B1:F2:48
```

This actually shows that the key was found and returned! It's not indicating an error at all. The "error" message is triggered because it's looking for the text "Alias name:" which isn't in the output format. This is a false negative.

### What to do:

1. **Your keystore and key alias are working properly** - Don't change anything with them.

2. **Update the Test Key Alias step** in your workflow: ```yaml
   - name: Test Key Alias if: always() run: | echo "Testing key alias..." keytool -list -keystore keystore-test/release.keystore -storepass "${{ secrets.KEYSTORE_PASSWORD }}" -alias "${{ secrets.KEY_ALIAS }}" > keystore-test/alias.txt 2>&1 || true

       # Check success by looking for the certificate fingerprint instead of "Alias name:"
       if grep -q "PrivateKeyEntry" keystore-test/alias.txt; then
         echo "✅ Key alias exists in the keystore"
         cat keystore-test/alias.txt
       else
         echo "❌ Key alias does not exist in the keystore or other error"
         echo "Error output:"
         cat keystore-test/alias.txt

         echo "Available aliases in the keystore (if any):"
         keytool -list -keystore keystore-test/release.keystore -storepass "${{ secrets.KEYSTORE_PASSWORD }}" 2>/dev/null | grep -i "alias" || echo "Could not list aliases"
       fi
   ```

For your F-Droid build workflow, everything should work fine now. The keystore file, password, and alias are all verified to be correct. The test is showing a false negative simply due to how it's parsing the output from keytool.