### PR TITLE
[UPDATE] Workflow to use variable used with proper instruction

### DIFF
--- a/.github/workflows/version-management.yml
+++ b/.github/workflows/version-management.yml
@@ -170,24 +170,30 @@ jobs:
           body: |
             This PR updates the version to ${{ inputs.version_name }} (${{ inputs.version_code }})
             
-            ### Release Notes:
+            ## 📋 Release Notes:
             ${{ inputs.release_notes }}
             
-            ### Changes:
+            ## 🔄 Changes Made:
             - Updated app/build.gradle.kts
             - Updated F-Droid metadata
             - Created changelog file
             
-            After merging this PR, please create a tag with: 
+            ## ⚡ Trigger CI Workflows (Do This First):
+            
+            Since this PR was created by a bot, CI workflows won't trigger automatically. To trigger them:
+            
             ```sh
-            git checkout main && git pull origin main
-            git tag ${{ env.GIT_TAG }} && git push origin ${{ env.GIT_TAG }}
+            git checkout ${{ inputs.branch_name }}-${{ inputs.version_name }}
+            git commit --allow-empty -m "chore: empty commit for triggering workflows" && git push
             ```
             
-            **Note**: Due to security restrictions, when this PR is opened, the CI workflows are not triggered automatically. To trigger the workflows, you can make an empty commit with the following command:
+            ## 🏷️ After Merging This PR:
+            
+            After merging this PR, create and push the release tag:
             
             ```sh
-            git commit --allow-empty -m "chore: empty commit for triggering workflows" && git push
+            git checkout main && git pull origin main
+            git tag v${{ inputs.version_name }} && git push origin v${{ inputs.version_name }}
             ```
           branch: ${{ env.BRANCH_NAME }}
           base: ${{ github.ref_name }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/version-management.yml` file to improve the structure and clarity of the version management workflow instructions. The changes include reformatting section headers, adding a new section to guide users on triggering CI workflows, and refining the steps for creating and pushing release tags.

### Workflow instruction improvements:

* Updated section headers for better readability, replacing "###" with "##" and adding emojis for clarity.
* Added a new section, "⚡ Trigger CI Workflows (Do This First)," explaining how to manually trigger CI workflows with an empty commit due to bot-related restrictions.
* Improved the instructions under "🏷️ After Merging This PR" to clarify the steps for creating and pushing release tags after merging.