### PR TITLE
[FIXED] Version bump workflow issues

### DIFF
--- a/.github/workflows/version-management.yml
+++ b/.github/workflows/version-management.yml
@@ -57,9 +57,6 @@ jobs:
       - name: Create branch for PR
         run: |
           BRANCH="${{ inputs.branch_name }}-${{ inputs.version_name }}"
-          git checkout -b $BRANCH
-          # Make sure we're working with a clean branch that's not dependent on origin
-          git update-ref -d refs/remotes/origin/$BRANCH || true
           echo "BRANCH_NAME=$BRANCH" >> $GITHUB_ENV
 
       - name: Extract current version info
@@ -141,6 +138,10 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: |
+            app/build.gradle.kts
+            metadata/
+            fastlane/
           commit-message: "chore: prepare release ${{ inputs.version_name }}"
           title: "Prepare release ${{ inputs.version_name }}"
           body: |
@@ -159,7 +160,7 @@ jobs:
             Since this PR was created by a bot, CI workflows won't trigger automatically. To trigger them:
             
             ```sh
-            git checkout ${{ inputs.branch_name }}-${{ inputs.version_name }}
+            git checkout ${{ env.BRANCH_NAME }}
             git commit --allow-empty -m "chore: empty commit for triggering workflows" && git push
             ```
             
@@ -171,5 +172,5 @@ jobs:
             git checkout main && git pull origin main
             git tag v${{ inputs.version_name }} && git push origin v${{ inputs.version_name }}
             ```
-          branch: ${{ inputs.branch_name }}-${{ inputs.version_name }}
-          base: ${{ github.ref_name }}
+          branch: ${{ env.BRANCH_NAME }}
+          base: main


### PR DESCRIPTION
Great! This time the workflow got much further and successfully created the commit with the version changes. The error occurred in the `peter-evans/create-pull-request` action when it tried to reset the branch to `origin/version-bump-2.0.3`, but that remote branch doesn't exist because we removed the manual push step.

The key error is:
```
fatal: ambiguous argument 'origin/version-bump-2.0.3': unknown revision or path not in the working tree.
```

This happens because the `peter-evans/create-pull-request` action expects to be able to reset to the remote branch, but since we removed the manual push step, the remote branch doesn't exist yet.

Let me fix this by adding a step to stage the changes before the `peter-evans/create-pull-request` action, and also ensure the branch is properly set up:
```

Made changes.

```
Actually, let me check the documentation for the `peter-evans/create-pull-request` action to understand the proper way to handle this. The issue might be that we need to set up the branch differently or use different parameters. Let me try a different approach by ensuring the branch starts from main and doesn't try to reset to a non-existent remote:
```

Made changes.

```
The lint errors are false positives - those environment variables are set in previous steps. Let me now also simplify the PR creation process by letting the action handle branch creation completely:
```

Made changes.

```
The lint errors are again false positives - the `BRANCH_NAME` environment variable is set in the previous step. Now I've made the following key changes:

1. **Removed manual branch creation** - Let the `peter-evans/create-pull-request` action handle branch creation completely
2. **Added `add-paths` parameter** - This tells the action which files to include in the commit
3. **Set `base: main`** - Explicitly set the base branch to main instead of using `${{ github.ref_name }}`
4. **Updated the branch reference** - Use `${{ env.BRANCH_NAME }}` in the instructions

This should fix the issue because:
- The action will create the branch from main
- It won't try to reset to a non-existent remote branch
- The `add-paths` parameter ensures the correct files are staged
- The action handles the entire PR creation process internally

Let's test this version and see if it resolves the issue.