### PR TITLE
[UPDATE] Change app name from `TRMNL Mirror` to just `TRMNL`

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -69,13 +69,13 @@ jobs:
       - name: Rename APK
         run: |
           mkdir -p artifact
-          cp app/build/outputs/apk/release/app-release.apk artifact/trmnl-mirror-v${{ steps.version.outputs.VERSION }}.apk
+          cp app/build/outputs/apk/release/app-release.apk artifact/trmnl-v${{ steps.version.outputs.VERSION }}.apk
 
       - name: Upload Release APK
         uses: actions/upload-artifact@v4
         with:
-          name: trmnl-mirror-app
-          path: artifact/trmnl-mirror-v${{ steps.version.outputs.VERSION }}.apk
+          name: trmnl-app
+          path: artifact/trmnl-v${{ steps.version.outputs.VERSION }}.apk
           # Use maximum allowed retention period
           # https://github.com/actions/upload-artifact?tab=readme-ov-file#retention-period
           retention-days: 30
@@ -101,8 +101,8 @@ jobs:
           echo "Found release ID: $RELEASE_ID"
           
           # Upload APK to the release
-          APK_FILE="artifact/trmnl-mirror-v${{ steps.version.outputs.VERSION }}.apk"
-          APK_NAME="trmnl-mirror-v${{ steps.version.outputs.VERSION }}.apk"
+          APK_FILE="artifact/trmnl-v${{ steps.version.outputs.VERSION }}.apk"
+          APK_NAME="trmnl-v${{ steps.version.outputs.VERSION }}.apk"
           
           echo "Uploading $APK_NAME to release..."
           

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contributing Guide
 
-Thank you for your interest in contributing to TRMNL Display Mirror App! This document provides guidelines and instructions to help you contribute effectively.
+Thank you for your interest in contributing to TRMNL App! This document provides guidelines and instructions to help you contribute effectively.
 
 ## Application Overview
 
-This guide will help you get started with the TRMNL Display Mirror Android application development.
+This guide will help you get started with the TRMNL Android application development.
 
 <details>
 
@@ -22,7 +22,7 @@ The app uses a modern Android architecture with the following components:
 
 #### Key Features/Screens
 
-- Main TRMNL Mirror Display visualization in `TrmnlMirrorDisplayScreen`
+- Main TRMNL visualization in `TrmnlMirrorDisplayScreen`
 - Settings management via `AppSettingsScreen`
 - Image refresh log/history in `DisplayRefreshLogScreen`
 - Background refresh scheduling with `TrmnlWorkScheduler` & `TrmnlImageRefreshWorker`
@@ -107,11 +107,11 @@ Automatic snapshot release builds are available in the [release workflow](https:
 - [Circuit UDF Architecture](https://slackhq.github.io/circuit/)
 - [Android Work Manager](https://developer.android.com/topic/libraries/architecture/workmanager)
 
-Thank you for contributing to TRMNL Display Mirror App!
+Thank you for contributing to TRMNL App!
 
 
 ## TRMNL App Image Loading Flow
-Here is a generated sequence diagram illustrating the flow of image loading in the TRMNL Display Mirror application.
+Here is a generated sequence diagram illustrating the flow of image loading in the TRMNL application.
 
 ```mermaid
 sequenceDiagram

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 [![Android CI](https://github.com/usetrmnl/trmnl-android/actions/workflows/android.yml/badge.svg)](https://github.com/usetrmnl/trmnl-android/actions/workflows/android.yml) [![Android Release Build](https://github.com/usetrmnl/trmnl-android/actions/workflows/android-release.yml/badge.svg)](https://github.com/usetrmnl/trmnl-android/actions/workflows/android-release.yml) [![latest-build](https://badgen.net/github/release/usetrmnl/trmnl-android?label=Latest%20Build)](https://github.com/usetrmnl/trmnl-android/releases/latest)
 
-# Android - TRMNL Display Mirror 🪞
-A simple app to mirror existing TRMNL's content to your Android devices like Phone, Tablet, e-Ink Display.
+# Android - TRMNL
+A simple app to show TRMNL's content to your Android devices like Phone, Tablet, e-Ink Display.
 
 ## Application Overview
 
-The TRMNL Display Mirror app serves as a digital display mirror for TRMNL e-ink devices. The app connects to the TRMNL API, fetches display data, and shows it on Android devices.
+The TRMNL app serves as a digital display for TRMNL e-ink devices and BYOS installations. The app connects to the TRMNL or BYOS API server, fetches display data, and shows it on Android devices. It can function both as a mirror for existing TRMNL devices or as a standalone TRMNL device connected directly to BYOS or TRMNL (with BYOD add-on) servers.
 
 ### Key Features
 
@@ -39,7 +39,7 @@ Check installable APK from Assets in [latest release](https://github.com/usetrmn
 ### 📱 F-Droid
 The app will *soon* be available on F-Droid, providing a free and open source Android app repository.
 1. Add the F-Droid repository to your F-Droid client
-2. Search for "TRMNL Display Mirror"
+2. Search for "TRMNL"
 3. Install the app
 -->
 

--- a/app/src/main/java/ink/trmnl/android/MainActivity.kt
+++ b/app/src/main/java/ink/trmnl/android/MainActivity.kt
@@ -33,8 +33,11 @@ import timber.log.Timber
 import javax.inject.Inject
 
 /**
- * Main activity for the TRMNL display mirror app.
- * This activity sets up the Circuit framework and handles navigation.
+ * Main activity for the TRMNL app.
+ *
+ * This activity serves as the entry point for the Android TRMNL application.
+ * It can function as either a mirror for existing TRMNL devices or as a
+ * standalone TRMNL display connected directly to BYOS servers.
  */
 @ContributesMultibinding(AppScope::class, boundType = Activity::class)
 @ActivityKey(MainActivity::class)

--- a/app/src/main/java/ink/trmnl/android/ui/display/OverlayDisplaySettingsView.kt
+++ b/app/src/main/java/ink/trmnl/android/ui/display/OverlayDisplaySettingsView.kt
@@ -30,11 +30,13 @@ import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_EXPANDED_L
 import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_MEDIUM_LOWER_BOUND
 
 /**
- * Displays a set of configuration and control actions for the TRMNL mirror display.
+ * Displays a set of configuration and control actions for the TRMNL display.
  *
- * This composable provides quick access to device configuration, manual image refresh,
- * playlist navigation, and viewing refresh logs. It adapts its layout and button sizes
- * based on the current window size class, making it suitable for both phones and tablets.
+ * This overlay provides quick access to common display controls such as:
+ * - Manual refresh functionality
+ * - Loading next playlist image
+ * - Viewing refresh history logs
+ * - Accessing app settings
  *
  * @param state The current state of the TRMNL mirror display, including refresh info and event sink.
  * @param windowSizeClass The current window size class, used to adapt the UI for different screen sizes.
@@ -109,7 +111,7 @@ internal fun OverlaySettingsView(
                 },
                 text = {
                     Text(
-                        "Configure Mirror Device",
+                        "Configure TRMNL",
                         style = fabTextStyle,
                         fontWeight = FontWeight.Bold,
                     )

--- a/app/src/main/java/ink/trmnl/android/ui/display/TrmnlMirrorDisplayScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/ui/display/TrmnlMirrorDisplayScreen.kt
@@ -346,7 +346,7 @@ fun TrmnlMirrorDisplayContent(
     }
 }
 
-@Preview(name = "Trmnl Mirror Display Image Preview")
+@Preview(name = "TRMNL Display Image Preview")
 @PreviewScreenSizes
 @Composable
 fun PreviewTrmnlMirrorDisplayImageContent() {
@@ -365,7 +365,7 @@ fun PreviewTrmnlMirrorDisplayImageContent() {
     }
 }
 
-@Preview(name = "Trmnl Mirror Display With Controls")
+@Preview(name = "TRMNL Display With Controls")
 @PreviewScreenSizes
 @Composable
 fun PreviewTrmnlMirrorDisplayWithControls() {
@@ -384,7 +384,7 @@ fun PreviewTrmnlMirrorDisplayWithControls() {
     }
 }
 
-@Preview(name = "Trmnl Mirror Display Error Content Preview")
+@Preview(name = "TRMNL Display Error Content Preview")
 @Composable
 fun PreviewTrmnlMirrorDisplayErrorContent() {
     Surface {

--- a/app/src/main/java/ink/trmnl/android/ui/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/ui/settings/AppSettingsScreen.kt
@@ -121,15 +121,13 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 /**
- * Screen for configuring the TRMNL mirror app settings.
+ * Screen for configuring the TRMNL app settings.
  *
- * This screen allows users to set up and validate their TRMNL access token,
- * which is required to connect to the TRMNL API service. It displays validation
- * results, image previews when successful, and provides options to save the
- * configuration which in turn schedules refresh job using [TrmnlWorkScheduler].
- *
- * The screen can be configured to either return to the mirror display after
- * saving or to pop back to the previous screen.
+ * This screen allows users to:
+ * - Configure API authentication (access token or device ID)
+ * - Set custom server URLs for BYOS installations
+ * - Configure refresh intervals and behavior
+ * - Manage display preferences
  */
 @Parcelize
 data class AppSettingsScreen(
@@ -338,7 +336,7 @@ class AppSettingsPresenter
                                         apiAccessToken = accessToken,
                                         deviceMacId = deviceMacId.ifBlank { null },
                                     )
-                                // For TRMNL mirror device type, use getCurrentDisplayData
+                                // For TRMNL device type, use getCurrentDisplayData
                                 // For all other device types, use getNextDisplayData
                                 // See https://discord.com/channels/1281055965508141100/1331360842809348106/1382865608236077086
                                 val response =
@@ -593,7 +591,7 @@ fun AppSettingsContent(
             )
 
             Text(
-                text = "Display Mirror Configuration",
+                text = "Display Configuration",
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center,

--- a/app/src/main/java/ink/trmnl/android/work/TrmnlImageRefreshWorker.kt
+++ b/app/src/main/java/ink/trmnl/android/work/TrmnlImageRefreshWorker.kt
@@ -23,7 +23,7 @@ import timber.log.Timber
 import javax.inject.Inject
 
 /**
- * Worker to refresh the image displayed on the TRMNL mirror display.
+ * Worker to refresh the image displayed on the TRMNL display.
  *
  * The worker result is observed in [MainActivity] and then updated via the [TrmnlImageUpdateManager].
  * Whenever the image is updated, the [TrmnlImageUpdateManager] will notify the observers.

--- a/app/src/main/java/ink/trmnl/android/work/TrmnlImageUpdateManager.kt
+++ b/app/src/main/java/ink/trmnl/android/work/TrmnlImageUpdateManager.kt
@@ -11,8 +11,11 @@ import kotlinx.coroutines.flow.asStateFlow
 import timber.log.Timber
 
 /**
- * Manages the image update process for the TRMNL mirror display.
- * Acts as a central source of truth for image updates from WorkManager.
+ * Manages the image update process for the TRMNL display.
+ *
+ * This manager handles communication between the background image refresh workers
+ * and the UI components that display the TRMNL images. It maintains a flow of
+ * image metadata that UI components can observe to update their content.
  */
 @SingleIn(AppScope::class)
 class TrmnlImageUpdateManager

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">TRMNL Mirror</string>
+    <string name="app_name">TRMNL</string>
 </resources>

--- a/fastlane/metadata/android/en-US/changelogs/15.txt
+++ b/fastlane/metadata/android/en-US/changelogs/15.txt
@@ -1,2 +1,2 @@
 - Updated to latest version 1.9.4
-- Latest TRMNL Mirror app with F-Droid support
+- Latest TRMNL app with F-Droid support

--- a/fastlane/metadata/android/en-US/changelogs/16.txt
+++ b/fastlane/metadata/android/en-US/changelogs/16.txt
@@ -1,2 +1,2 @@
 - Updated to the latest version (1.9.5)
-- Latest TRMNL Mirror app with F-Droid support
+- Latest TRMNL app with F-Droid support

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,4 +1,4 @@
-TRMNL Display Mirror serves as a digital display mirror for TRMNL e-ink devices. The app connects to the TRMNL API, fetches display data, and shows it on Android devices.
+TRMNL serves as a digital display for TRMNL e-ink devices and BYOS installations. The app connects to the TRMNL or BYOS API, fetches display data, and shows it on Android devices. It can function both as a mirror for existing TRMNL devices or as a standalone TRMNL display connected directly to BYOS servers.
 
 Key Features:
 • Token-based authentication with TRMNL/BYOS API

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-TRMNL Display Mirror
+TRMNL

--- a/metadata/ink.trmnl.android.yml
+++ b/metadata/ink.trmnl.android.yml
@@ -9,11 +9,11 @@ SourceCode: https://github.com/usetrmnl/trmnl-android
 IssueTracker: https://github.com/usetrmnl/trmnl-android/issues
 Changelog: https://github.com/usetrmnl/trmnl-android/releases
 
-AutoName: TRMNL Mirror
+AutoName: TRMNL
 
 RepoType: git
 Repo: https://github.com/usetrmnl/trmnl-android.git
-Binaries: https://github.com/usetrmnl/trmnl-android/releases/download/v%v/trmnl-mirror-v%v.apk
+Binaries: https://github.com/usetrmnl/trmnl-android/releases/download/v%v/trmnl-v%v.apk
 
 Builds:
   - versionName: 2.0.3

--- a/project-resources/prd/product-requirements-document.md
+++ b/project-resources/prd/product-requirements-document.md
@@ -1,14 +1,15 @@
-# TRMNL Display App - Product Requirements Document (PRD)
+# TRMNL App - Product Requirements Document (PRD)
 
 ## 1. Introduction
 
-The TRMNL Display app serves as a digital display mirror for TRMNL e-ink devices. It connects to the
-TRMNL API, fetches display data, and shows it on Android mobile devices. This app supports multiple
+The TRMNL app serves as a digital display for TRMNL e-ink devices and BYOS installations. It connects to the
+TRMNL or BYOS API, fetches display data, and shows it on Android mobile devices. This app can function both as a mirror
+for existing TRMNL devices or as a standalone TRMNL device connected directly to BYOS servers. The app supports multiple
 device types including official TRMNL devices, Bring Your Own Device (BYOD), and Bring Your Own Server
 (BYOS) configurations. The app provides automatic and manual refresh capabilities to keep the display
 synchronized with the TRMNL content.
 
-This document outlines the requirements for the TRMNL Display Mirror Android application.
+This document outlines the requirements for the TRMNL Android application.
 
 ## 2. User Requirements
 
@@ -198,7 +199,7 @@ This document outlines the requirements for the TRMNL Display Mirror Android app
 
 ## 6. Implementation Considerations for Cross-Platform Development
 
-This section provides guidance for teams implementing the TRMNL Display app on other platforms, ensuring feature parity while leveraging platform-specific capabilities.
+This section provides guidance for teams implementing the TRMNL app on other platforms, ensuring feature parity while leveraging platform-specific capabilities.
 
 ### iOS Specific
 
@@ -262,4 +263,4 @@ This section provides guidance for teams implementing the TRMNL Display app on o
 | LIM-11 | Flutter has more limited e-ink display optimization capabilities compared to native implementations.         |
 | LIM-12 | React Native may have performance limitations when handling large image rendering on low-end devices.        |
 
-This PRD provides a comprehensive guide for implementing and maintaining the TRMNL Display app. Development teams should use this document to ensure the application meets all required functionality while following platform-specific best practices.
+This PRD provides a comprehensive guide for implementing and maintaining the TRMNL app. Development teams should use this document to ensure the application meets all required functionality while following platform-specific best practices.


### PR DESCRIPTION
This avoids some confusion about this being just mirror app for TRMNL devices.

Example: https://www.reddit.com/r/trmnl/comments/1mn5ddy/comment/n8btj7o/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button