### PR TITLE
fix(playlist): Advance to next item on refresh

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,8 +42,8 @@ android {
         // ⚠️ App versioning update is required in multiple places.
         // 👇🏽 Use the following workflow to update versions everywhere automatically ♻️
         // https://github.com/usetrmnl/trmnl-android/actions/workflows/version-management.yml
-        versionCode = 22
-        versionName = "2.0.4"
+        versionCode = 23
+        versionName = "2.0.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/ink/trmnl/android/work/TrmnlImageRefreshWorker.kt
+++ b/app/src/main/java/ink/trmnl/android/work/TrmnlImageRefreshWorker.kt
@@ -77,12 +77,7 @@ class TrmnlImageRefreshWorker(
         // Fetch TRMNL display image - current or next from playlist based on request type
         // Also, if device type is BYOD or BYOS, we will always load the next playlist image
         // See https://discord.com/channels/1281055965508141100/1331360842809348106/1382865608236077086
-        val trmnlDisplayInfo: TrmnlDisplayInfo =
-            if (loadNextPluginImage || deviceConfig.type != TrmnlDeviceType.TRMNL) {
-                displayRepository.getNextDisplayData(deviceConfig)
-            } else {
-                displayRepository.getCurrentDisplayData(deviceConfig)
-            }
+        val trmnlDisplayInfo: TrmnlDisplayInfo = displayRepository.getNextDisplayData(deviceConfig)
 
         // Check for errors
         if (trmnlDisplayInfo.status.isHttpError()) {


### PR DESCRIPTION
### DescriptionSummary

This pull request addresses a critical bug where the Android client would get stuck on a single item in a playlist, failing to advance to the next one upon refresh. It also includes an update to the application's version number.

**The Problem**

The TrmnlImageRefreshWorker was using conditional logic to determine whether to fetch the current display data or the next display data. For standard TRMNL devices, this logic incorrectly defaulted to calling displayRepository.getCurrentDisplayData(), causing the same content to be loaded repeatedly during automatic or manual refreshes.

**The Solution**

The ambiguous conditional logic has been removed from TrmnlImageRefreshWorker.kt. The worker now makes an unconditional call to displayRepository.getNextDisplayData(deviceConfig).This change ensures that every refresh cycle correctly requests the next item in the sequence, allowing playlists to progress as intended.

**Additional Changes**

•versionCode has been incremented to 23.
•versionName has been updated to "2.0.5".