### PR TITLE
Fix issue #164: Enable playlist auto-advance for periodic refreshes

### DIFF
--- a/app/src/main/java/ink/trmnl/android/work/TrmnlWorkScheduler.kt
+++ b/app/src/main/java/ink/trmnl/android/work/TrmnlWorkScheduler.kt
@@ -113,6 +113,10 @@ class TrmnlWorkScheduler
                     ).setInputData(
                         workDataOf(
                             PARAM_REFRESH_WORK_TYPE to RefreshWorkType.PERIODIC.name,
+                            // Set to true so periodic refreshes advance the playlist (use /api/display endpoint)
+                            // instead of just reloading the current display (use /api/current_screen endpoint).
+                            // This enables automatic playlist cycling for TRMNL devices.
+                            PARAM_LOAD_NEXT_PLAYLIST_DISPLAY_IMAGE to true,
                         ),
                     ).addTag(IMAGE_REFRESH_PERIODIC_WORK_TAG)
                     .build()


### PR DESCRIPTION
- Added PARAM_LOAD_NEXT_PLAYLIST_DISPLAY_IMAGE=true to periodic work scheduler
- This ensures automatic refreshes call /api/display (next) instead of /api/current_screen
- Preserves existing behavior for manual 'Refresh Current' button (uses current screen API)
- Fixes playlist never advancing during automatic periodic refreshes on TRMNL devices

Fixes #164 

Related PR: https://github.com/usetrmnl/trmnl-android/pull/167