### PR TITLE
Revise release checklist for publishing and tagging

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -72,7 +72,24 @@ After the version management workflow has completed:
 
 
 2. **Follow pre and post merge command guidelinse**: Merge the PR. See PR description with guides.
-3. **Download signed release build**: Use the workflow that automatically signs and builds release APK.
+3. **Publish new release**: Publish release for the new tag at https://github.com/usetrmnl/trmnl-android/releases
+
+**Create a GitHub release**:
+   - Go to GitHub → Releases → Draft new release
+   - Select the tag created by the workflow
+   - Title: "Release v{VERSION_NAME}"
+   - Description: Copy content from the changelog file
+
+This will trigger another workflow to automatically build the release APK and upload to the release. Here are some snapshot that shows the workflow being triggered and uploaded to the new published release
+
+<img width="971" height="317" alt="Screenshot 2025-10-20 at 8 38 43 PM copy" src="https://github.com/user-attachments/assets/07c4ac18-adc0-426f-8125-c0bff8429f42" />
+<img width="1090" height="841" alt="Screenshot 2025-10-20 at 8 39 17 PM copy" src="https://github.com/user-attachments/assets/55d1452f-f7c6-47ae-aa3c-bf73be5aa68f" />
+<img width="1263" height="380" alt="Screenshot 2025-10-20 at 8 55 09 PM copy" src="https://github.com/user-attachments/assets/56acf2cd-521a-40a6-b2c4-380f644145f4" />
+
+
+
+<details><summary>In case APK is not attached automatically, follow this 👇</summary>
+**Download signed release build**: Use the workflow that automatically signs and builds release APK.
 
 Example PR with instructions:  
 <img width="1315" height="321" alt="Screenshot 2025-08-15 at 1 29 48 PM" src="https://github.com/user-attachments/assets/f600cb63-09f1-4731-bde5-afb54210bb5f" />
@@ -83,15 +100,8 @@ Workflow containing the built APK:
 Unzipped artifact that is used for release:
 <img width="710" height="51" alt="Screenshot 2025-08-15 at 1 30 25 PM" src="https://github.com/user-attachments/assets/71c1f97e-71f5-434b-aa74-a0ec24acf194" />
 
+</details>
 
-
-4. **Create a GitHub release**:
-   - Go to GitHub → Releases → Draft new release
-   - Select the tag created by the workflow
-   - Title: "TRMNL Android v{VERSION_NAME}"
-   - Description: Copy content from the changelog file
-   - Attach the built APK
-  
 
 ## Troubleshooting
 


### PR DESCRIPTION
Updated release checklist to include new steps for publishing a release and creating a GitHub release.