### PR TITLE
docs: Add guidance for Icons class and vector drawables

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -170,6 +170,17 @@ See `RELEASE_CHECKLIST.md` for complete release process.
 - **Always run:** `./gradlew formatKotlin` before committing
 - **Check only:** `./gradlew lintKotlin` (doesn't modify files)
 
+## Icons & Vector Drawables
+
+- **Custom Icons Class:** `ink.trmnl.android.ui.icons.Icons` (replaces deprecated `androidx.compose.material.icons`)
+- **Adding New Icons:**
+  1. Download icon from [Material Symbols](https://fonts.google.com/icons)
+  2. Convert to Android Vector Drawable (use Vector Asset Studio in Android Studio)
+  3. Add drawable to `app/src/main/res/drawable/`
+  4. Expose via `Icons` class with appropriate category (Default, Outlined, AutoMirrored)
+- **Usage:** `Icons.Default.Settings`, `Icons.Outlined.Warning`, `Icons.AutoMirrored.Filled.ArrowBack`
+- **Never use:** `androidx.compose.material.icons.Icons` (deprecated package)
+
 ## Testing
 
 - **Unit Tests:** `app/src/test/` (Robolectric, MockK, Truth assertions)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,25 @@ The project uses optimized Gradle settings based on best practices from the [Now
 - Check: `./gradlew lintKotlin` (no modifications)
 - Only customization: Allow PascalCase for `@Composable` functions
 
+## Icons & Vector Drawables
+
+**Custom Icons Class:** `ink.trmnl.android.ui.icons.Icons` replaces deprecated `androidx.compose.material.icons`
+
+- **Location:** `app/src/main/java/ink/trmnl/android/ui/icons/Icons.kt`
+- **Structure:** Nested objects matching Material Icons API
+  - `Icons.Default.*` - Filled icons (CheckCircle, Clear, DateRange, PlayArrow, Refresh, Settings, Share, Warning)
+  - `Icons.Outlined.*` - Outlined variants (Info, Warning)
+  - `Icons.AutoMirrored.Filled.*` - Auto-mirrored for RTL (ArrowBack, ArrowForward, List)
+
+**Adding New Icons:**
+1. Download from [Google Fonts Material Symbols](https://fonts.google.com/icons)
+2. Convert to Android Vector Drawable (use Vector Asset Studio in Android Studio)
+3. Save to `app/src/main/res/drawable/ic_[name]_[size]dp.xml`
+4. Expose in `Icons.kt` with `@Composable get() = ImageVector.vectorResource(id = R.drawable.ic_name)`
+5. Place in appropriate category (Default/Outlined/AutoMirrored)
+
+**Never use:** `androidx.compose.material.icons.Icons` (deprecated, issue #226)
+
 ## Testing
 
 - Unit tests: `app/src/test/` (Robolectric 4.14.1, MockK 1.14.2, Truth 1.4.4)


### PR DESCRIPTION
## Summary
Updates documentation to guide developers on using the custom `Icons` class introduced in #226 for adding new icons to the project.

## Changes

### `.github/copilot-instructions.md`
- Added new "Icons & Vector Drawables" section after "Code Style & Formatting"
- Documents the custom `ink.trmnl.android.ui.icons.Icons` class
- Provides step-by-step instructions for adding new icons
- Warns against using deprecated `androidx.compose.material.icons` package

### `CLAUDE.md`
- Added comprehensive "Icons & Vector Drawables" section after "Code Style"
- Documents existing icon structure (Default, Outlined, AutoMirrored categories)
- Lists currently available icons
- Provides detailed workflow for adding new icons via Material Symbols
- References issue #226 for context

## Why These Changes?
Issue #226 introduced a custom Icons class to replace the deprecated Material Icons package, but the documentation didn't explain how developers should add new icons. These updates ensure:
- Developers know to use the custom Icons class instead of the deprecated package
- Clear instructions for adding new icons from Material Symbols
- Consistent icon management across the codebase

## Related
- Closes: N/A (documentation only)
- Related: #226