### PR TITLE
chore(deps): Update dependencies including Circuit 0.27.1 → 0.31.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
-activityCompose = "1.10.1"
+activityCompose = "1.12.1"
 # https://developer.android.com/jetpack/androidx/releases/compose-material3-adaptive
-adaptive = "1.2.0-alpha06"
+adaptive = "1.2.0"
 agp = "8.9.2"
 anvil = "0.4.1"
-circuit = "0.27.1"
-composeBom = "2025.06.00"
-coreKtx = "1.16.0"
+circuit = "0.31.0"
+composeBom = "2025.12.00"
+coreKtx = "1.17.0"
 dagger = "2.56.2"
-espressoCore = "3.6.1"
-googleFonts = "1.8.2"
+espressoCore = "3.7.0"
+googleFonts = "1.10.0"
 junit = "4.13.2"
-junitVersion = "1.2.1"
+junitVersion = "1.3.0"
 kotlinxCoroutinesTest = "1.10.2"
 
 # Kotlin and KSP versions (must be in sync)
@@ -19,7 +19,7 @@ kotlinxCoroutinesTest = "1.10.2"
 kotlin = "2.1.10"
 ksp = "2.1.10-1.0.31"
 
-lifecycleRuntimeKtx = "2.9.1"
+lifecycleRuntimeKtx = "2.10.0"
 
 # Kotlin linter with built-in formatter
 # https://github.com/jeremymailen/kotlinter-gradle
@@ -43,22 +43,22 @@ moshi = "1.15.2"
 eithernet = "2.0.0"
 
 # https://developer.android.com/jetpack/androidx/releases/work
-workManager = "2.10.1"
+workManager = "2.11.0"
 
 # Coil
 # https://github.com/coil-kt/coil
-coil = "3.2.0"
+coil = "3.3.0"
 
-mockk = "1.14.2"
-truth = "1.4.4"
-robolectric = "4.14.1"
+mockk = "1.14.7"
+truth = "1.4.5"
+robolectric = "4.16"
 
-datastore = "1.1.7"
+datastore = "1.2.0"
 
 # https://developer.android.com/jetpack/androidx/releases/window
 # https://developer.android.com/develop/ui/compose/layouts/adaptive
-androidx-window = "1.4.0"
-coreKtxVersion = "1.6.1"
+androidx-window = "1.5.1"
+coreKtxVersion = "1.7.0"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }


### PR DESCRIPTION
## Summary
Updates 18 dependencies, with the primary focus on upgrading Circuit from 0.27.1 to 0.31.0.

## Circuit Migration (0.27.1 → 0.31.0)
✅ **Breaking changes reviewed and handled:**
- `rememberAnsweringNavigator` callback is no longer suspendable (0.31.0)
  - ✅ No code changes needed - our implementation already uses `scope.launch` internally
- Removed `kotlinx-immutable` dependency in Circuit (0.31.0)
  - ✅ Not used in our codebase
- Result delivery moved to `NavigableCircuitContent` (0.31.0)
  - ✅ No code changes needed

## Updated Dependencies

### AndroidX & Compose (7)
- `activityCompose`: 1.10.1 → 1.12.1
- `adaptive`: 1.2.0-alpha06 → 1.2.0 (stable release 🎉)
- `composeBom`: 2025.06.00 → 2025.12.00
- `coreKtx`: 1.16.0 → 1.17.0
- `lifecycleRuntimeKtx`: 2.9.1 → 2.10.0
- `androidx-window`: 1.4.0 → 1.5.1
- `googleFonts`: 1.8.2 → 1.10.0

### Circuit (1)
- `circuit`: 0.27.1 → 0.31.0 ⭐

### Libraries (3)
- `workManager`: 2.10.1 → 2.11.0
- `coil`: 3.2.0 → 3.3.0
- `datastore`: 1.1.7 → 1.2.0

### Testing (7)
- `espressoCore`: 3.6.1 → 3.7.0
- `junitVersion`: 1.2.1 → 1.3.0
- `mockk`: 1.14.2 → 1.14.7
- `truth`: 1.4.4 → 1.4.5
- `robolectric`: 4.14.1 → 4.16
- `coreKtxVersion`: 1.6.1 → 1.7.0

## Testing
✅ `./gradlew formatKotlin` - Success  
✅ `./gradlew lintKotlin testDebugUnitTest` - 89 tests passed  
✅ `./gradlew assembleDebug` - APK built successfully

## References
- Circuit Release Notes: https://github.com/slackhq/circuit/releases/tag/0.31.0
- Circuit 0.28.0 - 0.31.0 release notes reviewed for breaking changes