### PR TITLE
Add logging and documentation for DataStore preference strategy

### DIFF
--- a/app/src/main/java/ink/trmnl/android/data/TrmnlDeviceConfigDataStore.kt
+++ b/app/src/main/java/ink/trmnl/android/data/TrmnlDeviceConfigDataStore.kt
@@ -10,6 +10,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.squareup.anvil.annotations.optional.SingleIn
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
 import ink.trmnl.android.data.AppConfig.DEFAULT_REFRESH_INTERVAL_SEC
 import ink.trmnl.android.data.AppConfig.TRMNL_API_SERVER_BASE_URL
 import ink.trmnl.android.di.AppScope
@@ -134,7 +135,7 @@ class TrmnlDeviceConfigDataStore
          * ```
          */
         private val deviceModelPreferencesType =
-            com.squareup.moshi.Types.newParameterizedType(
+            Types.newParameterizedType(
                 Map::class.java,
                 String::class.java,
                 DeviceModelSelection::class.java,
@@ -234,13 +235,9 @@ class TrmnlDeviceConfigDataStore
                 val configJson = preferences[CONFIG_JSON_KEY]
                 if (configJson != null) {
                     try {
-                        val config = deviceConfigAdapter.fromJson(configJson)
+                        val config: TrmnlDeviceConfig? = deviceConfigAdapter.fromJson(configJson)
                         Timber.tag(TAG).d(
-                            "Loading device config (JSON): type=${config?.type}, userApiToken=${config
-                                ?.userApiToken
-                                ?.take(
-                                    8,
-                                )?.plus("...") ?: "null"}",
+                            "Loading device config (JSON): type=${config?.type}, userApiToken=${config?.userApiToken.obfuscated()}",
                         )
                         config
                     } catch (e: Exception) {
@@ -266,7 +263,7 @@ class TrmnlDeviceConfigDataStore
                     val userApiToken = preferences[USER_API_TOKEN_KEY]
 
                     Timber.tag(TAG).d(
-                        "Loading device config (legacy): type=$type, userApiToken=${userApiToken.obfuscated()}",
+                        "Loading device config (legacy): type=$type, deviceApiToken=${token.obfuscated()}",
                     )
 
                     if (token != null) {


### PR DESCRIPTION
## Overview
This PR adds comprehensive logging for user API token operations and documents the dual-storage approach used in `TrmnlDeviceConfigDataStore`.

## Changes

### Logging Enhancements
- ✅ Added `String?.obfuscated()` private extension function for secure token logging
- ✅ Log when saving user API token (shows first 8 chars)
- ✅ Log when retrieving user API token from DataStore
- ✅ Log when loading device config (both JSON and legacy paths)
- ✅ Log success/failure of device config save operations

**Example logs:**
```
12:15:14.566  D  Device config saved successfully
12:15:14.577  D  Loading device config (JSON): type=BYOD, userApiToken=user_ity...
```

### Documentation Improvements
- ✅ Document dual-storage approach (modern JSON + legacy individual fields)
- ✅ Explain loading priority: JSON first, then legacy migration path
- ✅ Describe saving behavior: writes both formats for backward compatibility
- ✅ Document device model preferences map structure with example JSON
- ✅ Add detailed KDoc for `deviceConfigFlow` and `saveDeviceConfig` methods
- ✅ Explain null handling for optional fields (remove vs. set)

### Code Quality
- ✅ Extracted token obfuscation logic into reusable extension function
- ✅ Replaced 5 instances of `take(8)?.plus("...") ?: "null"` pattern
- ✅ Improved code maintainability and reduced duplication

## Validation
- ✅ Verified logging output in device logs
- ✅ All format checks passed
- ✅ Code compiles successfully

## Benefits
- **Debugging:** Easier to validate that user tokens are persisted and loaded correctly
- **Maintainability:** Clear documentation of the storage strategy helps future developers
- **Security:** Token obfuscation ensures sensitive data isn't fully exposed in logs
- **Consistency:** Single extension function ensures uniform token logging across all operations