### PR TITLE
docs: Update all URLs from usetrmnl.com to trmnl.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ The TRMNL app serves as a digital display for TRMNL e-ink devices and BYOS insta
 - [x] Refresh history logging for tracking & validation
 
 ## 📜 Preconditions
-You must have a **valid** `access-token` or `ID` _(MAC Address)_ to access the [screen content](https://docs.usetrmnl.com/go/private-api/fetch-screen-content) using TRMNL server API.
+You must have a **valid** `access-token` or `ID` _(MAC Address)_ to access the [screen content](https://docs.trmnl.com/go/private-api/fetch-screen-content) using TRMNL server API.
 
 Here are some of the known ways you can get access to the `access-token`.
 
-1. You must own a [TRMNL](https://usetrmnl.com/) device with "developer edition" add-on purchased
-2. You have purchased their [BYOD](https://docs.usetrmnl.com/go/diy/byod) product.
-3. You have self-serve installation of TRMNL service using [BYOS](https://docs.usetrmnl.com/go/diy/byos)
+1. You must own a [TRMNL](https://trmnl.com/) device with "developer edition" add-on purchased
+2. You have purchased their [BYOD](https://docs.trmnl.com/go/diy/byod) product.
+3. You have self-serve installation of TRMNL service using [BYOS](https://docs.trmnl.com/go/diy/byos)
 
 
 ### 📱 Google Play Store
@@ -65,6 +65,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more details on how to get started an
 
 Your companion app to monitor and manage your TRMNL e-ink displays on the go.
 
-**TRMNL Android Buddy** is the essential companion app for managing your [TRMNL](https://usetrmnl.com) e-ink display devices. Monitor device health, track battery life over time, and stay on top of your displays' status—all from your Android phone.
+**TRMNL Android Buddy** is the essential companion app for managing your [TRMNL](https://trmnl.com) e-ink display devices. Monitor device health, track battery life over time, and stay on top of your displays' status—all from your Android phone.
 
 <a href="https://play.google.com/store/apps/details?id=ink.trmnl.android.buddy&pcampaignid=web_share" target="_blank"><img src="https://liquidlabs.ca/img/google-play.svg" height="45"></a>

--- a/app/src/main/java/ink/trmnl/android/data/AppConfig.kt
+++ b/app/src/main/java/ink/trmnl/android/data/AppConfig.kt
@@ -24,7 +24,7 @@ object AppConfig {
      * Base URL for the TRMNL API server.
      * Ref: https://github.com/usetrmnl/trmnl-android/issues/171
      */
-    const val TRMNL_API_SERVER_BASE_URL = "https://usetrmnl.com/"
+    const val TRMNL_API_SERVER_BASE_URL = "https://trmnl.com/"
 
     /**
      * URL for the TRMNL Android app on GitHub.
@@ -34,5 +34,5 @@ object AppConfig {
     /**
      * URL for the TRMNL main website.
      */
-    const val TRMNL_SITE_URL = "https://usetrmnl.com/"
+    const val TRMNL_SITE_URL = "https://trmnl.com/"
 }

--- a/app/src/main/java/ink/trmnl/android/model/TrmnlDeviceType.kt
+++ b/app/src/main/java/ink/trmnl/android/model/TrmnlDeviceType.kt
@@ -4,7 +4,7 @@ import androidx.annotation.Keep
 
 /**
  * Enum class to represent the type of TRMNL device and service.
- * - https://usetrmnl.com/developers
+ * - https://trmnl.com/developers
  */
 @Keep
 enum class TrmnlDeviceType {

--- a/app/src/main/java/ink/trmnl/android/network/TrmnlApiService.kt
+++ b/app/src/main/java/ink/trmnl/android/network/TrmnlApiService.kt
@@ -21,8 +21,8 @@ import retrofit2.http.Url
  * For user-level (account) API endpoints, see [TrmnlUserApiService].
  *
  * See:
- * - https://docs.usetrmnl.com/go
- * - https://docs.usetrmnl.com/go/private-api/introduction
+ * - https://docs.trmnl.com/go
+ * - https://docs.trmnl.com/go/private-api/introduction
  * - https://trmnl.com/api-docs/index.html (OpenAPI documentation)
  *
  * @see TrmnlDisplayRepository
@@ -33,7 +33,7 @@ interface TrmnlApiService {
         /**
          * Path for the TRMNL API endpoint that provides the next image in a playlist.
          *
-         * - https://docs.usetrmnl.com/go/private-api/fetch-screen-content#auto-advance-content
+         * - https://docs.trmnl.com/go/private-api/fetch-screen-content#auto-advance-content
          * - https://github.com/usetrmnl/byos_hanami?tab=readme-ov-file#display
          *
          * @see getNextDisplayData
@@ -43,7 +43,7 @@ interface TrmnlApiService {
         /**
          * Path for the TRMNL API endpoint that provides the current image in a playlist.
          *
-         * https://docs.usetrmnl.com/go/private-api/fetch-screen-content#current-screen
+         * https://docs.trmnl.com/go/private-api/fetch-screen-content#current-screen
          *
          * @see getCurrentDisplayData
          */
@@ -61,7 +61,7 @@ interface TrmnlApiService {
         /**
          * Path for the TRMNL API endpoint that provides the list of available device models.
          *
-         * https://help.usetrmnl.com/en/articles/11547008-device-model-faq
+         * https://help.trmnl.com/en/articles/11547008-device-model-faq
          *
          * @see getDeviceModels
          */
@@ -138,9 +138,9 @@ interface TrmnlApiService {
      * This endpoint provides information about all supported device models including
      * display specifications, supported palettes, and device characteristics.
      *
-     * See https://help.usetrmnl.com/en/articles/11547008-device-model-faq
+     * See https://help.trmnl.com/en/articles/11547008-device-model-faq
      *
-     * @param fullApiUrl The complete API URL to call (e.g., "https://usetrmnl.com/api/models")
+     * @param fullApiUrl The complete API URL to call (e.g., "https://trmnl.com/api/models")
      * @return An [ApiResult] containing [TrmnlModelsResponse] with the list of device models
      */
     @GET
@@ -161,7 +161,7 @@ interface TrmnlApiService {
      *
      * See https://discord.com/channels/1281055965508141100/1466924426460397765
      *
-     * @param fullApiUrl The complete API URL to call (e.g., "https://usetrmnl.com/api/devices/me")
+     * @param fullApiUrl The complete API URL to call (e.g., "https://trmnl.com/api/devices/me")
      * @param accessToken The device's API key (required)
      * @return An [ApiResult] containing [TrmnlDeviceResponse] with the device information
      */

--- a/app/src/main/java/ink/trmnl/android/network/TrmnlUserApiService.kt
+++ b/app/src/main/java/ink/trmnl/android/network/TrmnlUserApiService.kt
@@ -18,7 +18,7 @@ import retrofit2.http.Url
  * (Account API key), as opposed to device-level authentication.
  *
  * See:
- * - https://docs.usetrmnl.com/go
+ * - https://docs.trmnl.com/go
  * - https://trmnl.com/api-docs/index.html (OpenAPI documentation)
  */
 interface TrmnlUserApiService {
@@ -56,7 +56,7 @@ interface TrmnlUserApiService {
      *
      * **Authentication:** Requires Bearer token with user-level Account API key
      *
-     * @param fullApiUrl The complete API URL to call (e.g., "https://usetrmnl.com/api/me")
+     * @param fullApiUrl The complete API URL to call (e.g., "https://trmnl.com/api/me")
      * @param accessToken The bearer authentication token (format: "Bearer your_api_key")
      * @return An [ApiResult] containing [TrmnlUserResponse] with the user's information
      */
@@ -74,7 +74,7 @@ interface TrmnlUserApiService {
      *
      * **Authentication:** Requires Bearer token with user-level Account API key
      *
-     * @param fullApiUrl The complete API URL to call (e.g., "https://usetrmnl.com/api/devices/1")
+     * @param fullApiUrl The complete API URL to call (e.g., "https://trmnl.com/api/devices/1")
      * @param accessToken The bearer authentication token (format: "Bearer your_api_key")
      * @return An [ApiResult] containing [TrmnlDeviceResponse] with the device data
      */

--- a/app/src/main/java/ink/trmnl/android/network/model/TrmnlCurrentImageResponse.kt
+++ b/app/src/main/java/ink/trmnl/android/network/model/TrmnlCurrentImageResponse.kt
@@ -11,7 +11,7 @@ import com.squareup.moshi.JsonClass
  * {
  *   "status": 200,
  *   "refresh_rate": 3590,
- *   "image_url": "https://usetrmnl.com/plugin-image.bmp",
+ *   "image_url": "https://trmnl.com/plugin-image.bmp",
  *   "filename": "plugin-image",
  *   "rendered_at": null
  * }

--- a/app/src/main/java/ink/trmnl/android/network/model/TrmnlDisplayResponse.kt
+++ b/app/src/main/java/ink/trmnl/android/network/model/TrmnlDisplayResponse.kt
@@ -25,7 +25,7 @@ import ink.trmnl.android.util.HTTP_NONE
  * ```json
  * {
  *   "status": 0,
- *   "image_url": "https://usetrmnl.com/images/setup/sleep.bmp",
+ *   "image_url": "https://trmnl.com/images/setup/sleep.bmp",
  *   "filename": "sleep",
  *   "refresh_rate": 28498
  * }

--- a/app/src/main/java/ink/trmnl/android/ui/settings/AppSettingsScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/ui/settings/AppSettingsScreen.kt
@@ -1722,7 +1722,7 @@ private fun PreviewAppSettingsContentByod() {
             state =
                 AppSettingsScreen.State(
                     deviceType = TrmnlDeviceType.BYOD,
-                    serverBaseUrl = "https://usetrmnl.com",
+                    serverBaseUrl = "https://trmnl.com",
                     accessToken = "byod-access-token-here",
                     deviceMacId = "",
                     isByodMasterDevice = false,

--- a/app/src/main/java/ink/trmnl/android/ui/settings/DeviceTypeInfoTexts.kt
+++ b/app/src/main/java/ink/trmnl/android/ui/settings/DeviceTypeInfoTexts.kt
@@ -59,9 +59,9 @@ internal fun TrmnlDeviceTypeInfoText() {
 
             withLink(
                 LinkAnnotation.Url(
-                    url = "https://usetrmnl.com/dashboard",
+                    url = "https://trmnl.com/dashboard",
                     styles = TextLinkStyles(style = linkStyle),
-                    linkInteractionListener = { uriHandler.openUri("https://usetrmnl.com/dashboard") },
+                    linkInteractionListener = { uriHandler.openUri("https://trmnl.com/dashboard") },
                 ),
             ) {
                 withStyle(style = linkStyle) {
@@ -73,9 +73,9 @@ internal fun TrmnlDeviceTypeInfoText() {
 
             withLink(
                 LinkAnnotation.Url(
-                    url = "https://docs.usetrmnl.com/go/private-api/introduction",
+                    url = "https://docs.trmnl.com/go/private-api/introduction",
                     styles = TextLinkStyles(style = linkStyle),
-                    linkInteractionListener = { uriHandler.openUri("https://docs.usetrmnl.com/go/private-api/introduction") },
+                    linkInteractionListener = { uriHandler.openUri("https://docs.trmnl.com/go/private-api/introduction") },
                 ),
             ) {
                 withStyle(style = linkStyle) {
@@ -114,9 +114,9 @@ internal fun ByodDeviceTypeInfoText() {
 
             withLink(
                 LinkAnnotation.Url(
-                    url = "https://docs.usetrmnl.com/go/diy/byod-s",
+                    url = "https://docs.trmnl.com/go/diy/byod-s",
                     styles = TextLinkStyles(style = linkStyle),
-                    linkInteractionListener = { uriHandler.openUri("https://docs.usetrmnl.com/go/diy/byod-s") },
+                    linkInteractionListener = { uriHandler.openUri("https://docs.trmnl.com/go/diy/byod-s") },
                 ),
             ) {
                 withStyle(style = linkStyle) {
@@ -155,9 +155,9 @@ internal fun ByosDeviceTypeInfoText() {
 
             withLink(
                 LinkAnnotation.Url(
-                    url = "https://docs.usetrmnl.com/go/diy/byos",
+                    url = "https://docs.trmnl.com/go/diy/byos",
                     styles = TextLinkStyles(style = linkStyle),
-                    linkInteractionListener = { uriHandler.openUri("https://docs.usetrmnl.com/go/diy/byos") },
+                    linkInteractionListener = { uriHandler.openUri("https://docs.trmnl.com/go/diy/byos") },
                 ),
             ) {
                 withStyle(style = linkStyle) {

--- a/app/src/test/java/ink/trmnl/android/data/TrmnlDeviceConfigDataStoreTest.kt
+++ b/app/src/test/java/ink/trmnl/android/data/TrmnlDeviceConfigDataStoreTest.kt
@@ -659,7 +659,7 @@ class TrmnlDeviceConfigDataStoreTest {
                 TrmnlDeviceConfig(
                     type = TrmnlDeviceType.BYOD,
                     apiAccessToken = "test-token",
-                    apiBaseUrl = "https://usetrmnl.com",
+                    apiBaseUrl = "https://trmnl.com",
                     userApiToken = "user_test_token",
                     deviceId = 999,
                 )
@@ -683,7 +683,7 @@ class TrmnlDeviceConfigDataStoreTest {
             // Arrange - Save individual fields (legacy approach) without JSON
             deviceConfigDataStore.saveDeviceType(TrmnlDeviceType.BYOD)
             deviceConfigDataStore.saveAccessToken("test-token")
-            deviceConfigDataStore.saveServerUrl("https://usetrmnl.com")
+            deviceConfigDataStore.saveServerUrl("https://trmnl.com")
             deviceConfigDataStore.saveDeviceId(777)
 
             // Act
@@ -703,7 +703,7 @@ class TrmnlDeviceConfigDataStoreTest {
                 TrmnlDeviceConfig(
                     type = TrmnlDeviceType.BYOD,
                     apiAccessToken = "test-token",
-                    apiBaseUrl = "https://usetrmnl.com",
+                    apiBaseUrl = "https://trmnl.com",
                     deviceId = 123,
                 )
             deviceConfigDataStore.saveDeviceConfig(configWithDeviceId)

--- a/fastlane/metadata/android/en-US/changelogs/23.txt
+++ b/fastlane/metadata/android/en-US/changelogs/23.txt
@@ -1,5 +1,5 @@
 - Updated to the latest version (2.1.0)
-- Fixed API base URL to use usetrmnl.com domain
+- Fixed API base URL to use trmnl.com domain
 - Fixed HTTP 429 rate limit handling with retry logic
 - Fixed playlist auto-advance for periodic refreshes
 - Fixed accidental log deletion with confirmation dialog

--- a/fastlane/metadata/android/en-US/google_play_description.txt
+++ b/fastlane/metadata/android/en-US/google_play_description.txt
@@ -39,7 +39,7 @@ Perfect for:
 ✓ BYOS (Bring Your Own Server) installations
 ✓ Anyone with e-ink tablets looking for a smart display solution using TRMNL services
 
-Visit https://usetrmnl.com for more information about TRMNL devices and services.
+Visit https://trmnl.com for more information about TRMNL devices and services.
 
 
 CATEGORY

--- a/project-resources/trmnl-api/README.md
+++ b/project-resources/trmnl-api/README.md
@@ -5,8 +5,8 @@ This directory contains the OpenAPI specification for the TRMNL API.
 ## Resources
 
 - **OpenAPI Portal:** https://trmnl.com/api-docs/index.html
-- **API Documentation:** https://docs.usetrmnl.com/go
-- **Private API Docs:** https://docs.usetrmnl.com/go/private-api/introduction
+- **API Documentation:** https://docs.trmnl.com/go
+- **Private API Docs:** https://docs.trmnl.com/go/private-api/introduction
 
 ## Files
 


### PR DESCRIPTION
## Summary
Updates all URLs from `usetrmnl.com` to `trmnl.com` following TRMNL's domain migration.

## Changes
Updated 45 occurrences across 13 files:

### API & Configuration (5 files)
- **AppConfig.kt**: `TRMNL_API_SERVER_BASE_URL` and `TRMNL_SITE_URL`
- **TrmnlApiService.kt**: Documentation and example URLs
- **TrmnlUserApiService.kt**: Documentation and example URLs
- **TrmnlDeviceType.kt**: Developer documentation link
- **AppSettingsScreen.kt**: Default server URL

### UI Components (2 files)
- **DeviceTypeInfoTexts.kt**: All interactive links (dashboard, docs, BYOD, BYOS)
- **TrmnlDisplayResponse.kt** & **TrmnlCurrentImageResponse.kt**: Example JSON URLs

### Documentation (4 files)
- **README.md**: All TRMNL links and documentation references
- **fastlane/metadata/.../google_play_description.txt**: Marketing URLs
- **fastlane/metadata/.../changelogs/23.txt**: Changelog domain reference
- **project-resources/trmnl-api/README.md**: API documentation links
- **project-resources/google-play/google_play_description.txt**: Marketing URLs

### Tests (1 file)
- **TrmnlDeviceConfigDataStoreTest.kt**: Test data URLs

## Domain Mapping
- `usetrmnl.com` → `trmnl.com`
- `docs.usetrmnl.com` → `docs.trmnl.com`  
- `help.usetrmnl.com` → `help.trmnl.com`

## Testing
- ✅ All tests pass
- ✅ Code formatted with ktlint
- ✅ Debug APK builds successfully

## References
- Blog post: https://trmnl.com/blog/trmnl-dot-com
- Related PR: https://github.com/usetrmnl/api-docs/pull/8

Fixes #240