### PR TITLE
docs: Update remaining usetrmnl.com references to trmnl.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more details on how to get started an
 ---
 
 ## Related References 📖
-* https://usetrmnl.com/
-* https://usetrmnl.com/integrations
+* https://trmnl.com/
+* https://trmnl.com/integrations
 * https://github.com/usetrmnl/
 
 

--- a/app/src/main/java/ink/trmnl/android/network/TrmnlUserApiService.kt
+++ b/app/src/main/java/ink/trmnl/android/network/TrmnlUserApiService.kt
@@ -92,7 +92,7 @@ interface TrmnlUserApiService {
      *
      * **Authentication:** Requires Bearer token with user-level Account API key
      *
-     * @param fullApiUrl The complete API URL to call (e.g., "https://usetrmnl.com/api/devices/1")
+     * @param fullApiUrl The complete API URL to call (e.g., "https://trmnl.com/api/devices/1")
      * @param accessToken The bearer authentication token (format: "Bearer your_api_key")
      * @param updateRequest The device update request containing the fields to update
      * @return An [ApiResult] containing [TrmnlDeviceResponse] with the updated device data

--- a/fastlane/metadata/android/en-US/google_play_description.txt
+++ b/fastlane/metadata/android/en-US/google_play_description.txt
@@ -102,13 +102,13 @@ TRMNL is now officially available! Transform your Android device into a smart di
 📱 Requirements:
 • TRMNL device with developer edition, BYOD subscription, or BYOS installation
 
-Learn more at https://usetrmnl.com
+Learn more at https://trmnl.com
 
 
 🎉 Version 2.1.0 - Reliability & Performance Update
 
 🐛 Bug Fixes:
-• Fixed API connectivity with updated usetrmnl.com domain
+• Fixed API connectivity with updated trmnl.com domain
 • Fixed HTTP 429 rate limit handling with smart retry logic
 • Fixed playlist auto-advance for proper content cycling
 • Added confirmation dialog to prevent accidental log deletion


### PR DESCRIPTION
## Summary
Completes the domain migration from `usetrmnl.com` to `trmnl.com` by updating the 7 remaining references that were missed in PR #249.

## Changes
Updated 7 remaining occurrences across 4 files:

### Documentation (2 files)
- **README.md**: Related references section (2 URLs)
  - `https://usetrmnl.com/` → `https://trmnl.com/`
  - `https://usetrmnl.com/integrations` → `https://trmnl.com/integrations`

### API Documentation (1 file)
- **TrmnlUserApiService.kt**: `updateDevice()` method example URL
  - `https://usetrmnl.com/api/devices/1` → `https://trmnl.com/api/devices/1`

### Google Play Store (2 files)
- **fastlane/metadata/.../google_play_description.txt**:
  - "Learn more at" URL
  - Changelog domain reference
- **project-resources/google-play/google_play_description.txt**: Same updates

## Verification
```bash
grep -r "usetrmnl.com" .
# No results found
```

✅ All `usetrmnl.com` references have now been migrated to `trmnl.com`

## Testing
- ✅ Code formatted
- ✅ Debug APK builds successfully

Related to #240