### PR TITLE
[UPDATE] Info text for device type to be more precise

### DIFF
--- a/app/src/main/java/ink/trmnl/android/ui/settings/DeviceTypeInfoTexts.kt
+++ b/app/src/main/java/ink/trmnl/android/ui/settings/DeviceTypeInfoTexts.kt
@@ -55,7 +55,7 @@ internal fun TrmnlDeviceTypeInfoText() {
     val linkStyle = SpanStyle(color = MaterialTheme.colorScheme.primary, textDecoration = TextDecoration.Underline)
     val annotatedString =
         buildAnnotatedString {
-            append("Your TRMNL device token can be found in settings screen from your ")
+            append("Mirrors your existing TRMNL content. Your TRMNL device token can be found in settings screen from your ")
 
             withLink(
                 LinkAnnotation.Url(
@@ -110,7 +110,7 @@ internal fun ByodDeviceTypeInfoText() {
     val linkStyle = SpanStyle(color = MaterialTheme.colorScheme.primary, textDecoration = TextDecoration.Underline)
     val annotatedString =
         buildAnnotatedString {
-            append("Bring your own device (BYOD) works like a master TRMNL device. You will need BYOD add-on. ")
+            append("Bring your own device (BYOD) config. You will need BYOD add-on license. ")
 
             withLink(
                 LinkAnnotation.Url(
@@ -151,7 +151,7 @@ internal fun ByosDeviceTypeInfoText() {
     val linkStyle = SpanStyle(color = MaterialTheme.colorScheme.primary, textDecoration = TextDecoration.Underline)
     val annotatedString =
         buildAnnotatedString {
-            append("Bring your own server (BYOS) config.")
+            append("Bring your own server (BYOS) config. ")
 
             withLink(
                 LinkAnnotation.Url(


### PR DESCRIPTION
This pull request updates the information text shown to users in the settings screen for device types, clarifying the descriptions for both TRMNL and BYOD devices.

Device information text improvements:

* Updated the description in `TrmnlDeviceTypeInfoText` to clarify that the device mirrors existing TRMNL content. (`app/src/main/java/ink/trmnl/android/ui/settings/DeviceTypeInfoTexts.kt`)
* Revised the BYOD device description in `ByodDeviceTypeInfoText` to specify that a BYOD add-on license is required and to better reflect the configuration purpose. (`app/src/main/java/ink/trmnl/android/ui/settings/DeviceTypeInfoTexts.kt`)