### PR TITLE
[CHANGED] Phase 1: Replace Dagger/Anvil/KAPT with Metro DI (build config)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,10 +5,9 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.parcelize)
-    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.kotlinter)
     alias(libs.plugins.ksp)
-    alias(libs.plugins.anvil)
+    id("dev.zacsweers.metro")
 }
 
 // Load secret.properties file for local development
@@ -103,10 +102,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildFeatures {
         compose = true
         buildConfig = true
@@ -119,6 +114,12 @@ android {
         includeInApk = false
         // Disables dependency metadata when building Android App Bundles.
         includeInBundle = false
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 
@@ -147,13 +148,7 @@ dependencies {
     implementation(libs.core.ktx)
     ksp(libs.circuit.codegen)
 
-    implementation(libs.dagger)
-    // Dagger KSP support is in Alpha, not available yet. Using KAPT for now.
-    // https://dagger.dev/dev-guide/ksp.html
-    kapt(libs.dagger.compiler)
-
-    implementation(libs.anvil.annotations)
-    implementation(libs.anvil.annotations.optional)
+    implementation(libs.metrox.android)
 
     // Timber
     implementation(libs.timber)
@@ -198,10 +193,7 @@ dependencies {
 }
 
 ksp {
-    // Anvil-KSP
-    arg("anvil-ksp-extraContributingAnnotations", "com.slack.circuit.codegen.annotations.CircuitInject")
-    // kotlin-inject-anvil (requires 0.0.3+)
-    arg("kotlin-inject-anvil-contributing-annotations", "com.slack.circuit.codegen.annotations.CircuitInject")
+    arg("circuit.codegen.mode", "metro")
 }
 
 // Enable dynamic agent loading for tests needed by MockK

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,16 +16,11 @@ plugins {
     // Project: https://developer.android.com/kotlin/parcelize
     alias(libs.plugins.kotlin.parcelize) apply false
 
-    // Applies the Kotlin KAPT (Kotlin Annotation Processing Tool) plugin.
-    // Project: https://kotlinlang.org/docs/kapt.html
-    alias(libs.plugins.kotlin.kapt) apply false
-
     // Applies the Kotlin Symbol Processing (KSP) plugin.
     // Project: https://github.com/google/ksp
     alias(libs.plugins.ksp) apply false
 
-    // Applies the Anvil plugin for Dagger dependency injection.
-    // Project: https://github.com/square/anvil
-    // Also see: https://github.com/ZacSweers/anvil/blob/main/FORK.md
-    alias(libs.plugins.anvil) apply false
+    // Applies the Metro dependency injection plugin.
+    // Project: https://github.com/ZacSweers/metro
+    alias(libs.plugins.metro) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,11 +3,9 @@ activityCompose = "1.12.1"
 # https://developer.android.com/jetpack/androidx/releases/compose-material3-adaptive
 adaptive = "1.2.0"
 agp = "8.9.2"
-anvil = "0.4.1"
 circuit = "0.31.0"
 composeBom = "2025.12.00"
 coreKtx = "1.17.0"
-dagger = "2.56.2"
 espressoCore = "3.7.0"
 googleFonts = "1.10.0"
 junit = "4.13.2"
@@ -15,9 +13,13 @@ junitVersion = "1.3.0"
 kotlinxCoroutinesTest = "1.10.2"
 
 # Kotlin and KSP versions (must be in sync)
-# ⚠️ Kotlin version can't be higher than `2.1.10` due to known issue with Dagger
-kotlin = "2.1.10"
-ksp = "2.1.10-1.0.31"
+# KSP 2.3.0+ uses independent versioning (no longer tied to Kotlin version)
+kotlin = "2.3.20"
+ksp = "2.3.6"
+
+# Metro - compile-time DI framework powered by a Kotlin compiler plugin
+# https://github.com/ZacSweers/metro
+metro = "0.12.1"
 
 lifecycleRuntimeKtx = "2.10.0"
 
@@ -92,15 +94,9 @@ circuitx-effects = { group = "com.slack.circuit", name = "circuitx-effects", ver
 circuitx-gestureNav = { group = "com.slack.circuit", name = "circuitx-gesture-navigation", version.ref = "circuit" }
 circuitx-overlays = { group = "com.slack.circuit", name = "circuitx-overlays", version.ref = "circuit" }
 
-# https://dagger.dev/
-# https://dagger.dev/dev-guide/ksp
-dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
-dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
-
-# https://mvnrepository.com/artifact/com.squareup.anvil/annotations-optional
-# https://github.com/ZacSweers/anvil/blob/main/FORK.md
-anvil-annotations = { group = "dev.zacsweers.anvil", name = "annotations", version.ref = "anvil"}
-anvil-annotations-optional = { group = "dev.zacsweers.anvil", name = "annotations-optional", version.ref = "anvil"}
+# Metro - compile-time DI framework
+# https://github.com/ZacSweers/metro
+metrox-android = { group = "dev.zacsweers.metro", name = "metrox-android", version.ref = "metro" }
 
 # # https://developer.android.com/develop/ui/compose/text/fonts
 # https://mvnrepository.com/artifact/androidx.compose.ui/ui-text-google-fonts
@@ -157,8 +153,6 @@ test-turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
-
 # Add @Parcelize support
 # https://plugins.gradle.org/plugin/org.jetbrains.kotlin.plugin.parcelize
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
@@ -168,9 +162,9 @@ kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref =
 # https://github.com/google/ksp/releases
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp"}
 
-# Forked Anvil
-# https://github.com/ZacSweers/anvil/blob/main/FORK.md
-anvil = { id = "dev.zacsweers.anvil", version.ref = "anvil" }
+# Metro - compile-time DI compiler plugin
+# https://github.com/ZacSweers/metro
+metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 
 # Kotlin linter with built-in formatter
 # https://github.com/jeremymailen/kotlinter-gradle


### PR DESCRIPTION
## Summary

Phase 1 of the Dagger/Anvil to Metro DI migration. Updates all build configuration files - no source code changes yet.

Closes #272

## Changes

### `gradle/libs.versions.toml`
- Removed `anvil`, `dagger` version entries
- Bumped Kotlin `2.1.10` to `2.3.20` (required for Metro 0.10.0+; also fixes JDK 25 compatibility crash in `JavaVersion.parse`)
- Updated KSP to `2.3.6` (KSP now uses independent versioning from 2.3.0+, no longer tied to Kotlin version)
- Added `metro = "0.12.1"`
- Removed `dagger`, `dagger-compiler`, `anvil-annotations`, `anvil-annotations-optional` library entries
- Added `metrox-android` library entry (for Activity injection)
- Removed `kotlin-kapt` and `anvil` plugin entries
- Added `metro` plugin entry

### `build.gradle.kts` (root)
- Removed `kotlin.kapt` and `anvil` plugin declarations
- Added `metro` plugin declaration

### `app/build.gradle.kts`
- Removed `kotlin.kapt` and `anvil` plugins
- Added `dev.zacsweers.metro` plugin
- Removed `dagger`, `dagger-compiler`, `anvil-annotations`, `anvil-annotations-optional` dependencies
- Added `metrox-android` dependency
- Replaced Anvil KSP args with `circuit.codegen.mode = "metro"`
- Migrated deprecated `kotlinOptions { jvmTarget }` to `kotlin { compilerOptions { jvmTarget.set(...) } }` DSL

## Verification

Gradle configuration resolves successfully (`./gradlew help`) with JDK 21 + Kotlin 2.3.20 + Metro 0.12.1.
