### PR TITLE
docs: update markdown files to reflect current codebase state

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,7 +58,7 @@ This document provides essential information for GitHub Copilot agents working o
 - **JDK Version:** 21 (OpenJDK 21 - Temurin distribution recommended)
 - **Gradle:** 8.13 (via wrapper, do NOT install manually)
 - **Android SDK:** Compile SDK 36
-- **Build Tools:** Managed by Gradle plugin (AGP 8.9.2)
+- **Build Tools:** Managed by Gradle plugin (AGP 8.13.2)
 
 **IMPORTANT:** Always use `./gradlew` (Gradle wrapper) - NEVER use a system-installed gradle.
 
@@ -67,8 +67,8 @@ This document provides essential information for GitHub Copilot agents working o
 ### Main Source Structure
 ```
 app/src/main/java/ink/trmnl/android/
-├── MainActivity.kt               # App entry point (138 lines)
-├── TrmnlDisplayMirrorApp.kt     # Application class (51 lines)
+├── MainActivity.kt               # App entry point (140 lines)
+├── TrmnlDisplayMirrorApp.kt     # Application class (50 lines)
 ├── data/                         # Repositories, DataStore implementations
 ├── di/                          # Metro dependency injection modules
 ├── model/                       # Data models (TrmnlDeviceConfig, etc.)
@@ -82,7 +82,7 @@ app/src/main/java/ink/trmnl/android/
 - `app/build.gradle.kts` - Main build configuration, versioning (versionCode, versionName)
 - `build.gradle.kts` - Root project plugins
 - `settings.gradle.kts` - Project settings
-- `gradle.properties` - Gradle JVM settings (2GB heap)
+- `gradle.properties` - Gradle JVM settings (4GB heap)
 - `gradle/libs.versions.toml` - Centralized dependency versions
 - `app/proguard-rules.pro` - ProGuard rules (mostly default)
 - `app/src/main/AndroidManifest.xml` - App manifest, permissions
@@ -186,7 +186,7 @@ See `RELEASE_CHECKLIST.md` for complete release process.
 - **Unit Tests:** `app/src/test/` (Robolectric, MockK, Truth assertions)
 - **Run Tests:** `./gradlew testDebugUnitTest`
 - **Test Configuration:** Tests use JVM args `-XX:+EnableDynamicAgentLoading` (required for MockK)
-- **Current Status:** 89 tests, 3 skipped (as of last run)
+- **Current Status:** 216 tests, 3 skipped (as of last run)
 
 ## Making Code Changes
 
@@ -226,7 +226,7 @@ README.md              # Project overview and features
 RELEASE_CHECKLIST.md   # Release process documentation
 build.gradle.kts       # Root build configuration
 settings.gradle.kts    # Project settings
-gradle.properties      # Gradle configuration (JVM heap: 2GB)
+gradle.properties      # Gradle configuration (JVM heap: 4GB)
 gradlew / gradlew.bat  # Gradle wrapper scripts
 app/                   # Main application module
 gradle/                # Gradle wrapper JARs and version catalogs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,15 +8,15 @@ TRMNL Android is a native Android app that displays TRMNL e-ink device content o
 
 **Tech Stack:**
 - Language: Kotlin (100%)
-- Build: Gradle 8.13 with AGP 8.9.2
+- Build: Gradle 8.13 with AGP 8.13.2
 - Min SDK: 28 (Android 9.0 Pie), Target SDK: 36 (Android 16.0)
 - UI: Jetpack Compose with Circuit UDF architecture (Slack's unidirectional data flow)
 - DI: Metro 0.12.1 (dev.zacsweers.metro) with MetroX Android for compile-time DI
-- Background Work: WorkManager 2.10.1 (15-minute minimum interval limitation)
+- Background Work: WorkManager 2.11.2 (15-minute minimum interval limitation)
 - Networking: Retrofit 2.11.0 + OkHttp 4.12.0 + Moshi 1.15.2
-- Image Loading: Coil 3.2.0 with OkHttp integration
+- Image Loading: Coil 3.4.0 with OkHttp integration
 - API Result Modeling: EitherNet 2.0.0 from Slack
-- Data Storage: DataStore 1.1.7 for preferences/tokens
+- Data Storage: DataStore 1.2.1 for preferences/tokens
 - Logging: Timber 5.0.1
 
 ## Essential Build Commands
@@ -68,31 +68,60 @@ app/src/main/java/ink/trmnl/android/
 ├── MainActivity.kt               # Entry point, WorkInfo observer
 ├── TrmnlDisplayMirrorApp.kt     # Application class
 ├── data/                         # Repos, DataStore, ImageMetadata
-│   ├── TrmnlDisplayRepository.kt         # Main API data repository
-│   ├── TrmnlDeviceConfigDataStore.kt     # Device config (token, server)
+│   ├── AppConfig.kt                      # App configuration defaults
+│   ├── DeviceSetupInfo.kt                # BYOS device setup info
+│   ├── HttpResponseMetadata.kt           # HTTP response metadata
+│   ├── ImageMetadata.kt                  # Image state data class
 │   ├── ImageMetadataStore.kt             # Image state management
+│   ├── TrmnlDeviceConfigDataStore.kt     # Device config (token, server)
+│   ├── TrmnlDisplayInfo.kt               # Display info from API
+│   ├── TrmnlDisplayRepository.kt         # Main API data repository
+│   ├── TrmnlUserRepository.kt            # User info repository
 │   ├── log/                              # Refresh log management
 ├── di/                          # Metro DI modules
 │   ├── AppGraph.kt                       # Main app dependency graph
-│   ├── NetworkModule.kt                  # Retrofit, OkHttp, Moshi
+│   ├── AppScope.kt                       # App-scoped annotation
+│   ├── ApplicationContext.kt             # Context provider module
 │   ├── CircuitModule.kt                  # Circuit UI setup
+│   ├── DataStoreModule.kt                # DataStore provider
+│   ├── NetworkModule.kt                  # Retrofit, OkHttp, Moshi
+│   ├── WorkerModule.kt                   # WorkManager worker factory
 ├── model/                       # Data models
+│   ├── DeviceModelSelection.kt           # Device model selection state
+│   ├── SupportedDeviceModel.kt           # Supported device model list
 │   ├── TrmnlDeviceConfig.kt             # Device configuration
 │   ├── TrmnlDeviceType.kt               # Device type enum
 ├── network/                     # API layer
+│   ├── RateLimitInterceptor.kt           # API rate limit handling
+│   ├── Sleeper.kt                        # Delay/sleep utility
 │   ├── TrmnlApiService.kt               # Retrofit service
+│   ├── TrmnlUserApiService.kt           # User API endpoints
 │   ├── model/                           # API response models
+│   ├── util/                            # Networking utilities
 ├── ui/                          # Jetpack Compose screens
+│   ├── aboutapp/AppAboutScreen.kt              # About app screen
+│   ├── devicemodel/DeviceModelSelectorScreen.kt # Device model picker
 │   ├── display/TrmnlMirrorDisplayScreen.kt    # Main display
-│   ├── settings/AppSettingsScreen.kt           # Settings UI
+│   ├── icons/Icons.kt                         # Custom vector icons
 │   ├── refreshlog/DisplayRefreshLogScreen.kt  # Refresh history
+│   ├── settings/AppSettingsScreen.kt           # Settings UI
+│   ├── theme/                                  # Compose theme
+│   ├── FullScreenMode.kt                      # Immersive fullscreen
 ├── util/                        # Utilities
-│   ├── InputValidator.kt                # Token/URL validation
-│   ├── ImageSaver.kt                    # Save images to gallery
+│   ├── AndroidDeviceInfoProvider.kt   # Device info helper
+│   ├── CoilRequestUtils.kt            # Coil image request builder
+│   ├── DateTimeFormatter.kt           # Date/time formatting
+│   ├── ImageSaver.kt                  # Save images to gallery
+│   ├── InputValidator.kt              # Token/URL validation
+│   ├── NetworkExtensions.kt           # Network response extensions
+│   ├── WorkInfoExtensions.kt          # WorkInfo observation helpers
 ├── work/                        # Background work
-│   ├── TrmnlImageRefreshWorker.kt       # Worker implementation
-│   ├── TrmnlWorkScheduler.kt            # WorkManager scheduling
-│   ├── TrmnlImageUpdateManager.kt       # Image update flow
+│   ├── RefreshWorkResult.kt           # Worker result types
+│   ├── RefreshWorkType.kt             # Periodic vs one-time enum
+│   ├── TrmnlImageRefreshWorker.kt     # Worker implementation
+│   ├── TrmnlImageUpdateManager.kt     # Image update flow
+│   ├── TrmnlWorkScheduler.kt          # WorkManager scheduling
+│   ├── TrmnlWorkerFactory.kt          # Hilt-free worker factory
 ```
 
 ### Key Architectural Patterns
@@ -137,7 +166,7 @@ app/src/main/java/ink/trmnl/android/
 
 ## Configuration Files
 
-- `app/build.gradle.kts` - Version: versionCode=28, versionName="2.4.2"
+- `app/build.gradle.kts` - Version: versionCode=36, versionName="2.11.0"
 - `gradle/libs.versions.toml` - Centralized dependency versions
 - `.editorconfig` - ktlint rule: `ktlint_function_naming_ignore_when_annotated_with = Composable`
 - `secret.properties` (optional) - Local keystore secrets (not in repo)
@@ -209,7 +238,7 @@ The project uses optimized Gradle settings based on best practices from the [Now
 
 ## Code Style
 
-- Linter: ktlint via kotlinter-gradle 5.0.2
+- Linter: ktlint via kotlinter-gradle 5.5.0
 - Format: `./gradlew formatKotlin` (auto-fixes)
 - Check: `./gradlew lintKotlin` (no modifications)
 - Only customization: Allow PascalCase for `@Composable` functions
@@ -235,9 +264,9 @@ The project uses optimized Gradle settings based on best practices from the [Now
 
 ## Testing
 
-- Unit tests: `app/src/test/` (Robolectric 4.14.1, MockK 1.14.2, Truth 1.4.4)
+- Unit tests: `app/src/test/` (Robolectric 4.16.1, MockK 1.14.11, Truth 1.4.5)
 - Run: `./gradlew testDebugUnitTest`
-- Current status: 89 tests, 3 skipped
+- Current status: 216 tests, 3 skipped
 
 ## Important Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ To build a debug APK:
 The app uses standard Android build types (debug and release). There are no product flavors.
 
 **Build Types:**
-- **Debug**: Development builds with fake API support and debug keystore
+- **Debug**: Development builds with debug keystore and no code shrinking
 - **Release**: Production builds with code shrinking, ProGuard, and production keystore
 
 To build the release APK:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You must have a **valid** `access-token` or `ID` _(MAC Address)_ to access the [
 Here are some of the known ways you can get access to the `access-token`.
 
 1. You must own a [TRMNL](https://trmnl.com/) device with "developer edition" add-on purchased
-2. You have purchased their [BYOD](https://docs.trmnl.com/go/diy/byod) product.
+2. You have purchased their [BYOD](https://docs.trmnl.com/go/diy/byod-s) product.
 3. You have self-serve installation of TRMNL service using [BYOS](https://docs.trmnl.com/go/diy/byos)
 4. Your Android device OS version is `9.0` or higher (_for older devices try [trmnl-android-legacy-lite](https://github.com/layuso/trmnl-android-legacy-lite)_)
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -47,7 +47,6 @@ To update version, run the GitHub Actions workflow 'Version Management' with:
   - **Version code**: Integer value, must increase with each release
   - **Git tag** (optional): Defaults to v + version name
   - **Release notes**: Comma-separated release notes
-  - **Create PR**: Whether to create a pull request or commit directly
  
 <img width="357" height="719" alt="Screenshot 2025-08-15 at 1 01 32 PM" src="https://github.com/user-attachments/assets/8f0b308b-dc1f-406b-82bc-6d0d9b216426" />
 
@@ -64,17 +63,21 @@ This automated process ensures consistency across all version-related files with
 
 After the version management workflow has completed:
 
-1. **Review the PR** (if you ran the workflow with direct commits):
+1. **Review and merge the PR**:
 
 <img width="938" height="895" alt="Screenshot 2025-12-06 at 4 44 12 PM" src="https://github.com/user-attachments/assets/86c8af4e-b1df-4d4f-916d-1eaa33225d9a" />
 
 
-2. **Follow pre and post merge command guidelinse**: Merge the PR. See PR description with guides.
-3. **Publish new release**: Publish release for the new tag at https://github.com/usetrmnl/trmnl-android/releases
+2. **Follow pre and post merge command guidelines**: Merge the PR. See PR description with guides.
+3. **Create and push the release tag** (the PR body instructs with the exact command):
+   ```bash
+   git tag v{VERSION_NAME} && git push origin v{VERSION_NAME}
+   ```
+4. **Publish new release**: Go to https://github.com/usetrmnl/trmnl-android/releases
 
 **Create a GitHub release**:
-   - Go to GitHub → Releases → Draft new release
-   - Select the tag created by the workflow
+   - Click "Draft a new release"
+   - Select the tag you just pushed
    - Title: "Release v{VERSION_NAME}"
    - Description: Copy content from the changelog file
 


### PR DESCRIPTION
Updates stale documentation across 5 markdown files based on audit against actual code:

- **CLAUDE.md**: Bump AGP 8.9.2→8.13.2, WorkManager 2.10.1→2.11.2, Coil 3.2.0→3.4.0, DataStore 1.1.7→1.2.1, kotlinter 5.0.2→5.5.0, test libs (Robolectric, MockK, Truth), test count 89→216, versionCode 28→36, expand source tree listing
- **CONTRIBUTING.md**: Remove inaccurate 'fake API support' claim in debug builds (no such infrastructure exists)
- **.github/copilot-instructions.md**: Fix AGP version, heap size (2GB→4GB), line counts, test count
- **README.md**: Fix BYOD docs link (byod→byod-s to match code)
- **RELEASE_CHECKLIST.md**: Remove nonexistent 'Create PR' workflow input, fix 'direct commits' reference, add missing git tag creation step