### PR TITLE
ci: skip full build when only non-Android files change

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Check for Android-related changes
         id: check
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             android-related:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,20 +12,44 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - name: set up JDK
+
+      - name: Check for Android-related changes
+        id: check
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            android-related:
+              - 'app/**'
+              - 'build.gradle.kts'
+              - 'settings.gradle.kts'
+              - 'gradle.properties'
+              - 'gradle/**'
+              - 'gradlew'
+              - 'gradlew.bat'
+              - 'keystore/**'
+              - 'scripts/**'
+              - '.github/workflows/**'
+
+      - if: steps.check.outputs.android-related == 'true' || github.event_name == 'push'
+        name: set up JDK
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
-      # Automatic gradle caching using `actions/cache@v4`
-      # https://github.com/gradle/actions/tree/main/setup-gradle
-      - name: Setup Gradle
+      - if: steps.check.outputs.android-related == 'true' || github.event_name == 'push'
+        name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Run test and lint
+      - if: steps.check.outputs.android-related == 'true' || github.event_name == 'push'
+        name: Run test and lint
         run: ./gradlew lintKotlin testDebugUnitTest --parallel --daemon
 
-      - name: Build with Gradle
+      - if: steps.check.outputs.android-related == 'true' || github.event_name == 'push'
+        name: Build with Gradle
         run: ./gradlew assembleDebug --parallel --daemon
+
+      - if: steps.check.outputs.android-related != 'true' && github.event_name != 'push'
+        name: Skip build
+        run: echo "No Android-related changes detected — build skipped."


### PR DESCRIPTION
Optimizes CI to avoid wasting cycles on non-app changes.

## Changes

Adds `dorny/paths-filter@v3` to detect whether Android-related files changed:

- **PRs with Android changes**: runs lint, test, and build as before
- **PRs with only doc/resource changes**: instantly completes with a success message — no JDK setup, no Gradle, no build
- **Pushes to `main`**: always runs the full build for post-merge safety

Android-related file patterns matched:
`app/`, `build.gradle.kts`, `settings.gradle.kts`, `gradle.properties`, `gradle/`, `gradlew`, `gradlew.bat`, `keystore/`, `scripts/`, `.github/workflows/`

Non-Android files that now skip the build: `*.md`, `project-resources/`, `.devcontainer/`, `fastlane/`, `.githooks/`, `.editorconfig`, `.gitignore`, `LICENSE`, `.idea/`

## Why

Avoid wasting CI minutes and queue time on trivial doc-only PRs while still reporting a passing check for branch protection.